### PR TITLE
UISAUTCOMP-5 Fix search index wrong initial value

### DIFF
--- a/lib/context/AuthoritiesSearchContext.js
+++ b/lib/context/AuthoritiesSearchContext.js
@@ -26,6 +26,11 @@ const propTypes = {
 
 const AuthoritiesSearchContext = createContext();
 
+const defaultDropdownValueBySegment = {
+  [navigationSegments.search]: searchableIndexesValues.KEYWORD,
+  [navigationSegments.browse]: '',
+};
+
 const AuthoritiesSearchContextProvider = ({
   children,
   readParamsFromUrl,
@@ -43,11 +48,9 @@ const AuthoritiesSearchContextProvider = ({
 
   const initialSegment = searchParams.segment || navigationSegments.search;
 
-  const initialDropdownValue = initialSegment === navigationSegments.browse
-    ? searchParams.qindex || ''
-    : searchParams.qindex || searchableIndexesValues.KEYWORD;
+  const initialDropdownValue = searchParams.qindex || defaultDropdownValueBySegment[initialSegment];
 
-  const [navigationSegmentValue, setNavigationSegmentValue] = useState(initialSegment);
+  const [navigationSegmentValue, _setNavigationSegmentValue] = useState(initialSegment); // eslint-disable-line react/hook-use-state
   const [searchInputValue, setSearchInputValue] = useState(searchParams.query || '');
   const [searchQuery, setSearchQuery] = useState(searchParams.query || '');
   const [searchDropdownValue, setSearchDropdownValue] = useState(initialDropdownValue);
@@ -60,15 +63,17 @@ const AuthoritiesSearchContextProvider = ({
     option: searchParams.qindex,
   });
 
-  const resetAll = () => {
-    const dropdownValue = initialSegment === navigationSegments.browse
-      ? ''
-      : searchableIndexesValues.KEYWORD;
+  const setNavigationSegmentValue = value => {
+    setSearchDropdownValue(defaultDropdownValueBySegment[value]);
+    setSearchIndex(defaultDropdownValueBySegment[value]);
+    _setNavigationSegmentValue(value);
+  };
 
+  const resetAll = () => {
     setSearchInputValue('');
     setSearchQuery('');
-    setSearchDropdownValue(dropdownValue);
-    setSearchIndex(dropdownValue);
+    setSearchDropdownValue(defaultDropdownValueBySegment[navigationSegmentValue]);
+    setSearchIndex(defaultDropdownValueBySegment[navigationSegmentValue]);
     setFilters({});
     setIsGoingToBaseURL(true);
     setAdvancedSearchDefaultSearch(null);


### PR DESCRIPTION
## Description
Search index was resetting with initial navigation segment value. so if page was opened with search mode initially and you changed to browse - search index was `keyword`. But because `keyword` is not available in browse first available option was selected.
Fixed it by setting correct default value for each navigation segment

## Screenshots

https://user-images.githubusercontent.com/19309423/186122523-c4c3d6d3-d848-430f-8186-50fa7db7b414.mp4

## Issues
[UISAUTCOMP-5](https://issues.folio.org/browse/UISAUTCOMP-5)
