### PR TITLE
UISAUTCOMP-8 Correctly handle backwards slash in identifiers

### DIFF
--- a/lib/queries/useAuthorities/useAuthorities.js
+++ b/lib/queries/useAuthorities/useAuthorities.js
@@ -29,6 +29,7 @@ const buildRegularSearch = (searchIndex, query, filters) => {
     buildQuery({
       searchIndex,
       filters,
+      query,
     }),
     { interpolate: /%{([\s\S]+?)}/g },
   );
@@ -55,6 +56,7 @@ const buildAdvancedSearch = (advancedSearch, filters) => {
         searchIndex: index,
         comparator,
         filters,
+        query,
       }),
       { interpolate: /%{([\s\S]+?)}/g },
     );

--- a/lib/queries/useAuthorities/useAuthorities.test.js
+++ b/lib/queries/useAuthorities/useAuthorities.test.js
@@ -142,7 +142,7 @@ describe('Given useAuthorities', () => {
 
       await waitFor(() => !result.current.isLoading);
 
-      expect(result.current.query).toEqual('(identifiers.value==(n  00000001 ) and authRefType=="Authorized")');
+      expect(result.current.query).toEqual('(identifiers.value=="n  00000001 " and authRefType=="Authorized")');
     });
   });
 
@@ -166,7 +166,7 @@ describe('Given useAuthorities', () => {
         sortedColumn: '',
       }), { wrapper });
 
-      expect(result.current.query).toEqual('(keyword=="advancedTest1") not (identifiers.value==(advancedTest2) and authRefType=="Authorized")');
+      expect(result.current.query).toEqual('(keyword=="advancedTest1") not (identifiers.value=="advancedTest2" and authRefType=="Authorized")');
     });
   });
 });

--- a/lib/queries/utils/buildQuery.js
+++ b/lib/queries/utils/buildQuery.js
@@ -13,6 +13,7 @@ const buildQuery = ({
   comparator = '==',
   seeAlsoJoin = 'or',
   filters = {},
+  query,
 }) => {
   const indexData = searchableIndexesMap[searchIndex];
 
@@ -32,7 +33,9 @@ const buildQuery = ({
   if (searchIndex === searchableIndexesValues.IDENTIFIER) {
     const authRefType = searchResultListColumns.AUTH_REF_TYPE;
 
-    return `(${searchableIndexesValues.IDENTIFIER}==(%{query}) and ${authRefType}=="Authorized")`;
+    const queryTemplate = query.endsWith('\\') ? '(%{query})' : '"%{query}"';
+
+    return `(${searchableIndexesValues.IDENTIFIER}==${queryTemplate} and ${authRefType}=="Authorized")`;
   }
 
   const queryStrings = indexData.map(data => {
@@ -41,37 +44,27 @@ const buildQuery = ({
     const queryTemplate = name => `${name}${comparator}"%{query}"`;
 
     if (data.plain) {
-      const query = queryTemplate(data.name);
-
-      queryParts.push(query);
+      queryParts.push(queryTemplate(data.name));
     }
 
     if ((data.sft || data.saft) && data.plain) {
       const name = upperFirst(data.name);
 
       if (data.sft && !isExcludeSeeFrom) {
-        const query = queryTemplate(`sft${name}`);
-
-        queryParts.push(query);
+        queryParts.push(queryTemplate(`sft${name}`));
       }
 
       if (data.saft && !isExcludeSeeFromAlso) {
-        const query = queryTemplate(`saft${name}`);
-
-        queryParts.push(query);
+        queryParts.push(queryTemplate(`saft${name}`));
       }
     }
 
     if (data.sft && !data.plain && !isExcludeSeeFrom) {
-      const query = queryTemplate(data.name);
-
-      queryParts.push(query);
+      queryParts.push(queryTemplate(data.name));
     }
 
     if (data.saft && !data.plain && !isExcludeSeeFromAlso) {
-      const query = queryTemplate(data.name);
-
-      queryParts.push(query);
+      queryParts.push(queryTemplate(data.name));
     }
 
     return queryParts;

--- a/lib/queries/utils/buildQuery.test.js
+++ b/lib/queries/utils/buildQuery.test.js
@@ -10,6 +10,7 @@ describe('Given buildQuery', () => {
     it('should return correct query', () => {
       const query = buildQuery({
         searchIndex: searchableIndexesValues.PERSONAL_NAME,
+        query: 'somevalue',
       });
 
       expect(query).toBe('(personalName=="%{query}" or sftPersonalName=="%{query}" or saftPersonalName=="%{query}")');
@@ -20,6 +21,7 @@ describe('Given buildQuery', () => {
     it('should return an empty string', () => {
       const query = buildQuery({
         searchIndex: 'testIndex',
+        query: 'somevalue',
       });
 
       expect(query).toBe('');
@@ -30,6 +32,7 @@ describe('Given buildQuery', () => {
     it('should return correct query', () => {
       const query = buildQuery({
         searchIndex: searchableIndexesValues.GEOGRAPHIC_NAME,
+        query: 'somevalue',
       });
 
       expect(query).toBe('(geographicName=="%{query}" or sftGeographicName=="%{query}" or saftGeographicName=="%{query}")');
@@ -40,6 +43,7 @@ describe('Given buildQuery', () => {
     it('should return correct query', () => {
       const query = buildQuery({
         searchIndex: searchableIndexesValues.KEYWORD,
+        query: 'somevalue',
       });
 
       expect(query).toBe('(keyword=="%{query}")');
@@ -50,9 +54,10 @@ describe('Given buildQuery', () => {
     it('should return correct query', () => {
       const query = buildQuery({
         searchIndex: searchableIndexesValues.IDENTIFIER,
+        query: 'somevalue',
       });
 
-      expect(query).toBe('(identifiers.value==(%{query}) and authRefType=="Authorized")');
+      expect(query).toBe('(identifiers.value=="%{query}" and authRefType=="Authorized")');
     });
 
     describe('when isExcludedSeeFromLimiter is true', () => {
@@ -60,10 +65,33 @@ describe('Given buildQuery', () => {
         const query = buildQuery({
           searchIndex: searchableIndexesValues.IDENTIFIER,
           isExcludedSeeFromLimiter: true,
+          query: 'somevalue',
         });
 
-        expect(query).toBe('(identifiers.value==(%{query}) and authRefType=="Authorized")');
+        expect(query).toBe('(identifiers.value=="%{query}" and authRefType=="Authorized")');
       });
+    });
+  });
+
+  describe('when identifier with forward slash is provided', () => {
+    it('should return correct query', () => {
+      const query = buildQuery({
+        searchIndex: searchableIndexesValues.IDENTIFIER,
+        query: 'somevalue/',
+      });
+
+      expect(query).toBe('(identifiers.value=="%{query}" and authRefType=="Authorized")');
+    });
+  });
+
+  describe('when identifier with backward slash is provided', () => {
+    it('should return correct query', () => {
+      const query = buildQuery({
+        searchIndex: searchableIndexesValues.IDENTIFIER,
+        query: 'somevalue\\',
+      });
+
+      expect(query).toBe('(identifiers.value==(%{query}) and authRefType=="Authorized")');
     });
   });
 
@@ -71,6 +99,7 @@ describe('Given buildQuery', () => {
     it('should return correct query', () => {
       const query = buildQuery({
         searchIndex: 'childrenSubjectHeading',
+        query: 'somevalue',
       });
 
       expect(query).toBe('(keyword=="%{query}" and subjectHeadings=="b")');
@@ -84,6 +113,7 @@ describe('Given buildQuery', () => {
         filters: {
           [FILTERS.REFERENCES]: [REFERENCES_VALUES_MAP.excludeSeeFrom],
         },
+        query: 'somevalue',
       });
 
       expect(query).toEqual('(personalName=="%{query}" or saftPersonalName=="%{query}")');
@@ -95,6 +125,7 @@ describe('Given buildQuery', () => {
         filters: {
           [FILTERS.REFERENCES]: [REFERENCES_VALUES_MAP.excludeSeeFromAlso],
         },
+        query: 'somevalue',
       });
 
       expect(query).toEqual('(personalName=="%{query}" or sftPersonalName=="%{query}")');
@@ -109,6 +140,7 @@ describe('Given buildQuery', () => {
             REFERENCES_VALUES_MAP.excludeSeeFromAlso,
           ],
         },
+        query: 'somevalue',
       });
 
       expect(query).toEqual('(personalName=="%{query}")');


### PR DESCRIPTION
## Description
Identifiers should be handled like this:
- bslw85033892 will be searched as `identifiers.value=="bslw85033892"`
- bslw85033892/ will be searched as `identifiers.value=="bslw85033892/"`
- bslw85033892\ will be searched as `identifiers.value==(bslw85033892\)`

## Issues
[UISAUTCOMP-8](https://issues.folio.org/browse/UISAUTCOMP-8)
