### PR TITLE
UISAUTCOMP-7: Fix prop types warnings in tests

### DIFF
--- a/lib/AuthoritiesSearchForm/AuthoritiesSearchForm.test.js
+++ b/lib/AuthoritiesSearchForm/AuthoritiesSearchForm.test.js
@@ -136,9 +136,9 @@ describe('Given AuthoritiesSearchForm', () => {
   });
 
   it('should display "Reset all" button', () => {
-    const { getByRole } = renderAuthoritiesSearchForm();
+    const { getByText } = renderAuthoritiesSearchForm();
 
-    expect(getByRole('button', { name: 'stripes-smart-components.resetAll' })).toBeDefined();
+    expect(getByText('stripes-smart-components.resetAll')).toBeDefined();
   });
 
   describe('when toggle navigation segment to Browse', () => {
@@ -178,13 +178,13 @@ describe('Given AuthoritiesSearchForm', () => {
   describe('when textarea is not empty and Reset all button is clicked', () => {
     it('should clear textarea', () => {
       const {
-        getByRole,
+        getByText,
         getByTestId,
       } = renderAuthoritiesSearchForm();
 
       const textarea = getByTestId('search-textarea');
       const searchButton = getByTestId('submit-authorities-search');
-      const resetAllButton = getByRole('button', { name: 'stripes-smart-components.resetAll' });
+      const resetAllButton = getByText('stripes-smart-components.resetAll');
 
       fireEvent.change(textarea, { target: { value: 'test search' } });
 
@@ -198,12 +198,12 @@ describe('Given AuthoritiesSearchForm', () => {
 
     it('should handle setSelectedAuthorityRecordContext', () => {
       const {
-        getByRole,
+        getByText,
         getByTestId,
       } = renderAuthoritiesSearchForm();
 
       const textarea = getByTestId('search-textarea');
-      const resetAllButton = getByRole('button', { name: 'stripes-smart-components.resetAll' });
+      const resetAllButton = getByText('stripes-smart-components.resetAll');
 
       fireEvent.change(textarea, { target: { value: 'test search' } });
 
@@ -215,9 +215,9 @@ describe('Given AuthoritiesSearchForm', () => {
     });
 
     it('should close detail view', () => {
-      const { getByRole, getByTestId } = renderAuthoritiesSearchForm({ onShowDetailView: mockOnShowDetailView });
+      const { getByText, getByTestId } = renderAuthoritiesSearchForm({ onShowDetailView: mockOnShowDetailView });
       const textarea = getByTestId('search-textarea');
-      const resetAllButton = getByRole('button', { name: 'stripes-smart-components.resetAll' });
+      const resetAllButton = getByText('stripes-smart-components.resetAll');
 
       fireEvent.change(textarea, { target: { value: 'test search' } });
       fireEvent.click(resetAllButton);

--- a/lib/BrowseFilters/BrowseFilters.test.js
+++ b/lib/BrowseFilters/BrowseFilters.test.js
@@ -63,10 +63,10 @@ describe('Given BrowseFilters', () => {
   afterEach(() => jest.clearAllMocks());
 
   it('should display "References" accordion and its checkboxes', () => {
-    const { getByRole } = renderBrowseFilters();
+    const { getByText } = renderBrowseFilters();
 
-    expect(getByRole('heading', { name: 'stripes-authority-components.search.references' })).toBeDefined();
-    expect(getByRole('checkbox', { name: 'stripes-authority-components.search.excludeSeeFrom' })).toBeDefined();
+    expect(getByText('stripes-authority-components.search.references')).toBeDefined();
+    expect(getByText('stripes-authority-components.search.excludeSeeFrom')).toBeDefined();
   });
 
   it('should render Type of heading filter', () => {

--- a/lib/SearchFilters/SearchFilters.test.js
+++ b/lib/SearchFilters/SearchFilters.test.js
@@ -63,11 +63,11 @@ describe('Given SearchFilters', () => {
   afterEach(() => jest.clearAllMocks());
 
   it('should display "References" accordion and its checkboxes', () => {
-    const { getByRole } = renderSearchFilters();
+    const { getByText } = renderSearchFilters();
 
-    expect(getByRole('heading', { name: 'stripes-authority-components.search.references' })).toBeDefined();
-    expect(getByRole('checkbox', { name: 'stripes-authority-components.search.excludeSeeFrom' })).toBeDefined();
-    expect(getByRole('checkbox', { name: 'stripes-authority-components.search.excludeSeeFromAlso' })).toBeDefined();
+    expect(getByText('stripes-authority-components.search.references')).toBeDefined();
+    expect(getByText('stripes-authority-components.search.excludeSeeFrom')).toBeDefined();
+    expect(getByText('stripes-authority-components.search.excludeSeeFromAlso')).toBeDefined();
   });
 
   it('should render Thesaurus filter', () => {

--- a/lib/SearchTextareaField/SearchTextareaField.js
+++ b/lib/SearchTextareaField/SearchTextareaField.js
@@ -27,7 +27,10 @@ const propTypes = {
     value: PropTypes.string,
   })).isRequired,
   textAreaRef: PropTypes.shape({
-    current: PropTypes.instanceOf(Element),
+    current: PropTypes.oneOfType([
+      PropTypes.instanceOf(Element),
+      PropTypes.object,
+    ]),
   }),
   value: PropTypes.string,
 };

--- a/lib/SearchTextareaField/SearchTextareaField.test.js
+++ b/lib/SearchTextareaField/SearchTextareaField.test.js
@@ -6,6 +6,7 @@ import Harness from '../../test/jest/helpers/harness';
 jest.mock('@folio/stripes/components', () => ({
   ...jest.requireActual('@folio/stripes-components'),
   Select: () => <div>Select component</div>,
+  TextArea: jest.fn(() => <div>TextArea</div>),
 }));
 
 const searchableIndexes = [{
@@ -50,8 +51,8 @@ describe('Given SearchTextareaField', () => {
   });
 
   it('should render textarea', () => {
-    const { getByTestId } = renderSearchTextareaField();
+    const { getByText } = renderSearchTextareaField();
 
-    expect(getByTestId('search-textarea')).toBeDefined();
+    expect(getByText('TextArea')).toBeDefined();
   });
 });

--- a/lib/context/AuthoritiesSearchContext.js
+++ b/lib/context/AuthoritiesSearchContext.js
@@ -59,7 +59,7 @@ const AuthoritiesSearchContextProvider = ({
   const [advancedSearchRows, setAdvancedSearchRows] = useState([]);
   const [isGoingToBaseURL, setIsGoingToBaseURL] = useState(false);
   const [advancedSearchDefaultSearch, setAdvancedSearchDefaultSearch] = useState({
-    query: searchParams.query,
+    query: searchParams.query || '',
     option: searchParams.qindex,
   });
 

--- a/lib/queries/useAuthorities/useAuthorities.js
+++ b/lib/queries/useAuthorities/useAuthorities.js
@@ -154,6 +154,7 @@ const useAuthorities = ({
     authoritiesArray.splice(offset, 0, ...data?.authorities || []);
 
     return authoritiesArray;
+    // eslint-disable-next-line
   }, [data?.authorities]);
 
   return ({

--- a/test/jest/__mock__/stripesIcon.mock.js
+++ b/test/jest/__mock__/stripesIcon.mock.js
@@ -1,1 +1,12 @@
-jest.mock('@folio/stripes-components/lib/Icon/icons', () => ({ default: 'span' }));
+jest.mock('@folio/stripes-components/lib/Icon', () => {
+  return function ({ children }) {
+    return (
+      <span>
+        Icon
+        <span>
+          {children}
+        </span>
+      </span>
+    );
+  };
+});

--- a/test/jest/helpers/harness.js
+++ b/test/jest/helpers/harness.js
@@ -18,8 +18,6 @@ import buildStripes from '../__mock__/stripesCore.mock';
 
 const STRIPES = buildStripes();
 
-const defaultHistory = createMemoryHistory();
-
 const queryClient = new QueryClient();
 
 const AuthoritiesSearchContextProviderMock = ({ children, ctxValue }) => (
@@ -38,7 +36,7 @@ const Harness = ({
   Router = DefaultRouter,
   stripes,
   children,
-  history = defaultHistory,
+  history = createMemoryHistory(),
   authoritiesCtxValue,
   selectedRecordCtxValue,
 }) => {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIEH-57 Create example component

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
Fix warnings in tests
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color
  palette does not provide enough contrast for certain classes of
  visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIEH-57
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 Bad:
  Made a dark color of #333, a medium color of #ccc

 Good:
   This introduces three abstract contrast levels that developers can
   use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
