### PR TITLE
UISAUTCOMP-15 Results List : Click Link icon/button to select a MARC authority record

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@
 - [UISAUTCOMP-9](https://issues.folio.org/browse/UISAUTCOMP-9) Add the marc view component, hide it after a filter change, add the ability to close it without redirection
 - [UISAUTCOMP-12](https://issues.folio.org/browse/UISAUTCOMP-12) CLONE - Default search query change to return - authRefType=Authorized
 - [UISAUTCOMP-14](https://issues.folio.org/browse/UISAUTCOMP-14) Add the Expand the Search & filter pane option
+- [UISAUTCOMP-15](https://issues.folio.org/browse/UISAUTCOMP-15) Results List : Click Link icon/button to select a MARC authority record

--- a/lib/SearchResultsList/SearchResultsList.js
+++ b/lib/SearchResultsList/SearchResultsList.js
@@ -7,7 +7,6 @@ import { useIntl } from 'react-intl';
 import noop from 'lodash/noop';
 
 import {
-  Checkbox,
   MultiColumnList,
   Icon,
 } from '@folio/stripes/components';
@@ -27,6 +26,7 @@ const propTypes = {
   authorities: PropTypes.arrayOf(AuthorityShape).isRequired,
   columnMapping: PropTypes.object,
   columnWidths: PropTypes.object,
+  formatter: PropTypes.object,
   hasFilters: PropTypes.bool.isRequired,
   hasNextPage: PropTypes.bool,
   hasPrevPage: PropTypes.bool,
@@ -44,13 +44,9 @@ const propTypes = {
   pageSize: PropTypes.number.isRequired,
   query: PropTypes.string.isRequired,
   renderHeadingRef: PropTypes.func.isRequired,
-  selectAll: PropTypes.bool,
-  selectedRows: PropTypes.object,
   sortedColumn: PropTypes.string,
   sortOrder: PropTypes.string,
   toggleFilterPane: PropTypes.func.isRequired,
-  toggleRowSelection: PropTypes.func,
-  toggleSelectAll: PropTypes.func,
   totalResults: PropTypes.number,
   visibleColumns: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
@@ -59,22 +55,19 @@ const SearchResultsList = ({
   authorities,
   columnWidths,
   columnMapping,
+  formatter,
   totalResults,
   loading,
   loaded,
   pageSize,
   onNeedMoreData,
   visibleColumns,
-  selectedRows,
   sortedColumn,
   sortOrder,
   onHeaderClick,
   isFilterPaneVisible,
   query,
   toggleFilterPane,
-  toggleRowSelection,
-  toggleSelectAll,
-  selectAll,
   hasFilters,
   hidePageIndices,
   hasNextPage,
@@ -87,40 +80,12 @@ const SearchResultsList = ({
   const [selectedAuthorityRecord, setSelectedAuthorityRecord] = useContext(SelectedAuthorityRecordContext);
 
   const defaultColumnMapping = {
-    [searchResultListColumns.SELECT]: (
-      <Checkbox
-        onChange={() => toggleSelectAll()}
-        name="select all authorities"
-        checked={selectAll}
-        title={selectAll
-          ? intl.formatMessage({ id: 'stripes-authority-components.search-results-list.selectAll' })
-          : intl.formatMessage({ id: 'stripes-authority-components.search-results-list.unselectAll' })
-        }
-      />
-    ),
     [searchResultListColumns.AUTH_REF_TYPE]: intl.formatMessage({ id: 'stripes-authority-components.search-results-list.authRefType' }),
     [searchResultListColumns.HEADING_REF]: intl.formatMessage({ id: 'stripes-authority-components.search-results-list.headingRef' }),
     [searchResultListColumns.HEADING_TYPE]: intl.formatMessage({ id: 'stripes-authority-components.search-results-list.headingType' }),
   };
 
-  const formatter = {
-    // eslint-disable-next-line react/prop-types
-    select: ({ id, ...rowData }) => id && (
-      <div // eslint-disable-line jsx-a11y/click-events-have-key-events
-        tabIndex="0"
-        role="button"
-        onClick={e => e.stopPropagation()}
-      >
-        <Checkbox
-          checked={Boolean(selectedRows[id])}
-          aria-label={intl.formatMessage({ id: 'ui-inventory.instances.rows.select' })}
-          onChange={() => toggleRowSelection({
-            id,
-            ...rowData,
-          })}
-        />
-      </div>
-    ),
+  const defaultFormatter = {
     authRefType: authority => {
       return authority.authRefType === AUTH_REF_TYPES.AUTHORIZED
         ? <b>{authority.authRefType}</b>
@@ -170,10 +135,16 @@ const SearchResultsList = ({
   return (
     <MultiColumnList
       hasMargin
-      columnMapping={columnMapping || defaultColumnMapping}
+      columnMapping={{
+        ...defaultColumnMapping,
+        ...columnMapping,
+      }}
       columnWidths={columnWidths}
       contentData={authorities}
-      formatter={formatter}
+      formatter={{
+        ...defaultFormatter,
+        ...formatter,
+      }}
       id="authority-result-list"
       onNeedMoreData={onNeedMoreData}
       visibleColumns={visibleColumns}
@@ -214,7 +185,8 @@ const SearchResultsList = ({
 SearchResultsList.propTypes = propTypes;
 
 SearchResultsList.defaultProps = {
-  columnMapping: null,
+  columnMapping: {},
+  formatter: {},
   columnWidths: {
     [searchResultListColumns.SELECT]: { min: 30, max: 30 },
     [searchResultListColumns.AUTH_REF_TYPE]: { min: 200 },
@@ -227,12 +199,8 @@ SearchResultsList.defaultProps = {
   itemToView: null,
   onRowFocus: null,
   onHeaderClick: null,
-  selectAll: null,
-  selectedRows: null,
   sortedColumn: null,
   sortOrder: null,
-  toggleRowSelection: null,
-  toggleSelectAll: null,
   totalResults: NaN,
 };
 

--- a/lib/SearchResultsList/SearchResultsList.test.js
+++ b/lib/SearchResultsList/SearchResultsList.test.js
@@ -154,7 +154,6 @@ describe('Given SearchResultsList', () => {
           searchResultListColumns.HEADING_REF,
           searchResultListColumns.HEADING_TYPE,
         ],
-        selectedRows: {},
       });
 
       expect(queryByText('stripes-authority-components.search-results-list.select')).toBeDefined();

--- a/lib/constants/searchResultsListColumns.js
+++ b/lib/constants/searchResultsListColumns.js
@@ -3,4 +3,5 @@ export const searchResultListColumns = {
   AUTH_REF_TYPE: 'authRefType',
   HEADING_REF: 'headingRef',
   HEADING_TYPE: 'headingType',
+  LINK: 'link',
 };


### PR DESCRIPTION
## Description
Add ability to provide additional columns to the MCL component

## Screenshots

https://user-images.githubusercontent.com/19309423/189883443-8c6e642c-3c8b-47be-982d-a22efbe3d62e.mp4

## Issues
[UISAUTCOMP-15](https://issues.folio.org/browse/UISAUTCOMP-15)

## Related PRs
https://github.com/folio-org/ui-plugin-find-authority/pull/28
https://github.com/folio-org/ui-marc-authorities/pull/199