### PR TITLE
UISAUTCOMP-17 Use browse query for filters, fix NULL source filter label

### DIFF
--- a/lib/AuthoritySourceFilter/AuthoritySourceFilter.js
+++ b/lib/AuthoritySourceFilter/AuthoritySourceFilter.js
@@ -34,13 +34,21 @@ const AuthoritySourceFilter = ({
     return values.reduce((acc, { id, totalRecords }) => {
       const sourceFile = sourceFiles.find(file => file.id === id);
 
+      if (id === 'NULL') {
+        return [...acc, {
+          id,
+          label: intl.formatMessage({ id: 'stripes-authority-components.search.sourceFileId.nullOption' }),
+          totalRecords,
+        }];
+      }
+
       return [...acc, {
         id,
         label: sourceFile?.name || id,
         totalRecords,
       }];
     }, []);
-  }, [values, sourceFiles]);
+  }, [values, sourceFiles, intl]);
 
   return (
     <MultiSelectionFacet

--- a/lib/AuthoritySourceFilter/AuthoritySourceFilter.test.js
+++ b/lib/AuthoritySourceFilter/AuthoritySourceFilter.test.js
@@ -29,6 +29,9 @@ const values = [{
 }, {
   id: '3',
   totalRecords: 2,
+}, {
+  id: 'NULL',
+  totalRecords: 1,
 }];
 
 const renderAuthoritySourceFilter = (props = {}) => render(
@@ -73,6 +76,18 @@ describe('Given AuthoritySourceFilter', () => {
 
       expect(queryByText('Option 3')).toBeNull();
       expect(getByText('3')).toBeDefined();
+    });
+  });
+
+  describe('when source filter option id is NULL', () => {
+    it('should display "Not specified"', () => {
+      const {
+        getByText,
+        queryByText,
+      } = renderAuthoritySourceFilter();
+
+      expect(queryByText('NULL')).toBeNull();
+      expect(getByText('stripes-authority-components.search.sourceFileId.nullOption')).toBeDefined();
     });
   });
 });

--- a/lib/BrowseFilters/BrowseFilters.js
+++ b/lib/BrowseFilters/BrowseFilters.js
@@ -8,6 +8,7 @@ import { useIntl } from 'react-intl';
 import { AuthoritiesSearchContext } from '../';
 import { ReferencesFilter } from '../ReferencesFilter';
 import { MultiSelectionFacet } from '../MultiSelectionFacet';
+import { AuthoritySourceFilter } from '../AuthoritySourceFilter';
 import { useSectionToggle } from '../hooks';
 import { useFacets } from '../queries';
 import { FILTERS } from '../constants';
@@ -35,6 +36,7 @@ const BrowseFilters = ({
 
   const [filterAccordions, { handleSectionToggle }] = useSectionToggle({
     [FILTERS.HEADING_TYPE]: false,
+    [FILTERS.AUTHORITY_SOURCE]: true,
   });
 
   const selectedFacets = getSelectedFacets(filterAccordions);
@@ -54,18 +56,14 @@ const BrowseFilters = ({
   return (
     <>
       {isVisible(FILTERS.AUTHORITY_SOURCE) &&
-        <MultiSelectionFacet
-          id={FILTERS.AUTHORITY_SOURCE}
-          label={intl.formatMessage({ id: `stripes-authority-components.search.${FILTERS.AUTHORITY_SOURCE}` })}
-          name={FILTERS.AUTHORITY_SOURCE}
+        <AuthoritySourceFilter
           open={filterAccordions[FILTERS.AUTHORITY_SOURCE]}
-          options={facets[FILTERS.AUTHORITY_SOURCE]?.values}
+          values={facets[FILTERS.AUTHORITY_SOURCE]?.values || []}
           selectedValues={filters[FILTERS.AUTHORITY_SOURCE]}
-          onFilterChange={applyFilters}
           onClearFilter={filter => onClearFilter({ filter, setFilters })}
-          displayClearButton={!!filters[FILTERS.AUTHORITY_SOURCE]?.length}
+          onFilterChange={applyFilters}
           handleSectionToggle={handleSectionToggle}
-          isPending={isLoading}
+          isLoading={isLoading}
         />
       }
       {isVisible(FILTERS.REFERENCES) &&

--- a/lib/queries/useAuthoritiesBrowse/useAuthoritiesBrowse.js
+++ b/lib/queries/useAuthoritiesBrowse/useAuthoritiesBrowse.js
@@ -47,12 +47,10 @@ const useBrowseRequest = ({
 
   const headingTypeQuery = buildHeadingTypeQuery(searchIndex);
 
+  const query = [...cqlSearch, ...cqlFilters, headingTypeQuery].filter(Boolean).join(' and ');
+
   const searchParams = {
-    query: (
-      [...cqlSearch, ...cqlFilters, headingTypeQuery]
-        .filter(Boolean)
-        .join(' and ')
-    ),
+    query,
     limit: pageSize,
     precedingRecordsCount,
   };
@@ -87,6 +85,7 @@ const useBrowseRequest = ({
     firstResult,
     lastResult,
     startingSearch,
+    query,
   });
 };
 
@@ -236,6 +235,7 @@ const useAuthoritiesBrowse = ({
     isLoading: allRequestsFetching,
     isLoaded: allRequestsFetched,
     handleLoadMore,
+    query: mainRequest.query,
   });
 };
 

--- a/translations/stripes-authority-components/en.json
+++ b/translations/stripes-authority-components/en.json
@@ -12,6 +12,7 @@
   "search.headingType": "Type of heading",
   "search.references": "References",
   "search.sourceFileId": "Authority source",
+  "search.sourceFileId.nullOption": "Not specified",
   "search.excludeSeeFrom": "Exclude see from",
   "search.excludeSeeFromAlso": "Exclude see from also",
 


### PR DESCRIPTION
## Description
Pass query to request for filters to get available filters for current browse
Show "Not specified" for NULL source filter option

## Screenshots

https://user-images.githubusercontent.com/19309423/192990106-f4330fe8-9fdf-4a1e-b565-acca514137a5.mp4



## Issues
[UISAUTCOMP-17](https://issues.folio.org/browse/UISAUTCOMP-17)