### PR TITLE
UISAUTCOMP-21: Make MCL row unclickable when a placeholder row is dis…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@
 - [UISAUTCOMP-15](https://issues.folio.org/browse/UISAUTCOMP-15) Results List : Click Link icon/button to select a MARC authority record
 - [UISAUTCOMP-13](https://issues.folio.org/browse/UISAUTCOMP-13) Browse | The pagination doesn't reset when the user changes the search option and uses the same search query.
 - [UISAUTCOMP-17](https://issues.folio.org/browse/UISAUTCOMP-17) FE: MARC authority: Create an Authority source facet
+- [UISAUTCOMP-21](https://issues.folio.org/browse/UISAUTCOMP-21) Make MCL row unclickable when a placeholder row is displayed

--- a/lib/SearchResultsList/SearchResultsList.js
+++ b/lib/SearchResultsList/SearchResultsList.js
@@ -115,6 +115,10 @@ const SearchResultsList = ({
   };
 
   const onRowClick = (e, row) => {
+    if (row.isAnchor) {
+      return;
+    }
+
     setSelectedAuthorityRecord(row);
   };
 


### PR DESCRIPTION
## Purpose
The entire row should not be clickable. The `onRowClick `prop in the `MultiColumnList `.

## Approach
Terminate the `onRowClick` on anchors.

## Screenshots
[screen-capture (2).webm](https://user-images.githubusercontent.com/111242500/193585374-8db3063e-47ed-480b-8589-80c731110399.webm)


## Issues
[UISAUTCOMP-21](https://issues.folio.org/browse/UISAUTCOMP-21)