### PR TITLE
UISAUTCOMP-21

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,4 @@
 - [UISAUTCOMP-15](https://issues.folio.org/browse/UISAUTCOMP-15) Results List : Click Link icon/button to select a MARC authority record
 - [UISAUTCOMP-13](https://issues.folio.org/browse/UISAUTCOMP-13) Browse | The pagination doesn't reset when the user changes the search option and uses the same search query.
 - [UISAUTCOMP-17](https://issues.folio.org/browse/UISAUTCOMP-17) FE: MARC authority: Create an Authority source facet
+- [UISAUTCOMP-21](https://issues.folio.org/browse/UISAUTCOMP-21) Make MCL row unclickable when a placeholder row is displayed

--- a/lib/SearchResultsList/SearchResultsList.js
+++ b/lib/SearchResultsList/SearchResultsList.js
@@ -115,6 +115,10 @@ const SearchResultsList = ({
   };
 
   const onRowClick = (e, row) => {
+    if (row.isAnchor) {
+      return;
+    }
+
     setSelectedAuthorityRecord(row);
   };
 

--- a/lib/SearchResultsList/SearchResultsList.js
+++ b/lib/SearchResultsList/SearchResultsList.js
@@ -115,7 +115,7 @@ const SearchResultsList = ({
   };
 
   const onRowClick = (e, row) => {
-    if (row.isAnchor) {
+    if (row.isAnchor && !row.isExactMatch) {
       return;
     }
 


### PR DESCRIPTION
## Purpose
When clicking on exact match row triggers the "something went wrong" issue.

## Approach
Check if row is anchor and row is not an exact match then terminate `onRowClick` behavior.

## Issues
[UISAUTCOMP-21](https://issues.folio.org/browse/UISAUTCOMP-21)