### PR TITLE
UISAUTCOMP-19: added a11y tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@
 - [UISAUTCOMP-13](https://issues.folio.org/browse/UISAUTCOMP-13) Browse | The pagination doesn't reset when the user changes the search option and uses the same search query.
 - [UISAUTCOMP-17](https://issues.folio.org/browse/UISAUTCOMP-17) FE: MARC authority: Create an Authority source facet
 - [UISAUTCOMP-21](https://issues.folio.org/browse/UISAUTCOMP-21) Make MCL row unclickable when a placeholder row is displayed
+- [UISAUTCOMP-19](https://issues.folio.org/browse/UISAUTCOMP-19) Add a11y tests

--- a/lib/AuthoritySourceFilter/AuthoritySourceFilter.test.js
+++ b/lib/AuthoritySourceFilter/AuthoritySourceFilter.test.js
@@ -1,5 +1,7 @@
 import { render } from '@testing-library/react';
 
+import { runAxeTest } from '@folio/stripes-testing';
+
 import AuthoritySourceFilter from './AuthoritySourceFilter';
 import Harness from '../../test/jest/helpers/harness';
 
@@ -56,6 +58,14 @@ describe('Given AuthoritySourceFilter', () => {
     const { getAllByText } = renderAuthoritySourceFilter();
 
     expect(getAllByText('stripes-authority-components.search.sourceFileId')).toBeDefined();
+  });
+
+  it('should render with no axe errors', async () => {
+    const { container } = renderAuthoritySourceFilter();
+
+    await runAxeTest({
+      rootNode: container,
+    });
   });
 
   describe('when source file id is mapped to a label', () => {

--- a/lib/FacetOptionFormatter/FacetOptionFormatter.test.js
+++ b/lib/FacetOptionFormatter/FacetOptionFormatter.test.js
@@ -1,5 +1,7 @@
 import { render } from '@testing-library/react';
 
+import { runAxeTest } from '@folio/stripes-testing';
+
 import FacetOptionFormatter from './FacetOptionFormatter';
 
 import Harness from '../../test/jest/helpers/harness';
@@ -26,5 +28,13 @@ describe('Given FacetOptionFormatter', () => {
     const { getByText } = renderFacetOptionFormatter();
 
     expect(getByText('(1000)')).toBeDefined();
+  });
+
+  it('should render with no axe errors', async () => {
+    const { container } = renderFacetOptionFormatter();
+
+    await runAxeTest({
+      rootNode: container,
+    });
   });
 });

--- a/lib/FilterNavigation/FilterNavigation.test.js
+++ b/lib/FilterNavigation/FilterNavigation.test.js
@@ -3,6 +3,8 @@ import {
   fireEvent,
 } from '@testing-library/react';
 
+import { runAxeTest } from '@folio/stripes-testing';
+
 import FilterNavigation from './FilterNavigation';
 import { navigationSegments } from '../constants';
 import Harness from '../../test/jest/helpers/harness';
@@ -29,6 +31,14 @@ describe('Given FilterNavigation', () => {
 
     expect(getByTestId('segment-navigation-search')).toBeDefined();
     expect(getByTestId('segment-navigation-browse')).toBeDefined();
+  });
+
+  it('should render with no axe errors', async () => {
+    const { container } = renderFilterNavigation();
+
+    await runAxeTest({
+      rootNode: container,
+    });
   });
 
   describe('when toggle navigation segment', () => {

--- a/lib/MultiSelectionFacet/MultiSelectionFacet.test.js
+++ b/lib/MultiSelectionFacet/MultiSelectionFacet.test.js
@@ -1,7 +1,10 @@
 import { render } from '@testing-library/react';
 
+import { runAxeTest } from '@folio/stripes-testing';
+
 import MultiSelectionFacet from './MultiSelectionFacet';
 import Harness from '../../test/jest/helpers/harness';
+
 
 jest.mock('@folio/stripes/components', () => ({
   ...jest.requireActual('@folio/stripes/components'),
@@ -46,5 +49,13 @@ describe('Given MultiSelectionFacet', () => {
     const { getByText } = renderMultiSelectionFacet();
 
     expect(getByText('MultiSelection')).toBeDefined();
+  });
+
+  it('should render with no axe errors', async () => {
+    const { container } = renderMultiSelectionFacet();
+
+    await runAxeTest({
+      rootNode: container,
+    });
   });
 });

--- a/lib/ReferencesFilter/ReferencesFilter.test.js
+++ b/lib/ReferencesFilter/ReferencesFilter.test.js
@@ -5,6 +5,8 @@ import {
   screen,
 } from '@testing-library/react';
 
+import { runAxeTest } from '@folio/stripes-testing';
+
 import { ReferencesFilter } from './ReferencesFilter';
 import { navigationSegments } from '../constants';
 
@@ -44,6 +46,14 @@ describe('ReferencesFilter', () => {
     act(() => user.click(excludeSeeFromOption));
 
     expect(defaultProps.onChange).toHaveBeenCalled();
+  });
+
+  it('should render with no axe errors', async () => {
+    const { container } = renderReferencesFilter();
+
+    await runAxeTest({
+      rootNode: container,
+    });
   });
 
   describe('when navigation segment is Browse', () => {

--- a/lib/SearchTextareaField/SearchTextareaField.test.js
+++ b/lib/SearchTextareaField/SearchTextareaField.test.js
@@ -1,5 +1,7 @@
 import { render } from '@testing-library/react';
 
+import { runAxeTest } from '@folio/stripes-testing';
+
 import SearchTextareaField from './SearchTextareaField';
 import Harness from '../../test/jest/helpers/harness';
 
@@ -54,5 +56,13 @@ describe('Given SearchTextareaField', () => {
     const { getByText } = renderSearchTextareaField();
 
     expect(getByText('TextArea')).toBeDefined();
+  });
+
+  it('should render with no axe errors', async () => {
+    const { container } = renderSearchTextareaField();
+
+    await runAxeTest({
+      rootNode: container,
+    });
   });
 });


### PR DESCRIPTION
## Purpose
Need to add a11y tests with `runAxeTest` helper from @folio/stripes-testing module.

## Issues
[UISAUTCOMP-19](https://issues.folio.org/browse/UISAUTCOMP-19)