### PR TITLE
UISAUTCOMP-22 Long browse queries don't display properly in a not-exact match placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-authoriy-components
 
+## [1.1.0] (IN PROGRESS)
+
+- [UISAUTCOMP-22](https://issues.folio.org/browse/UISAUTCOMP-22) Long browse queries don't display properly in a not-exact match placeholder
+
 ## [1.0.0] (https://github.com/folio-org/stripes-authority-components/tree/v1.0.0) (2022-10-25)
 
 - [UISAUTCOMP-1](https://issues.folio.org/browse/UISAUTCOMP-1) stripes-authority-components: Create a repository

--- a/lib/SearchResultsList/SearchResultsList.css
+++ b/lib/SearchResultsList/SearchResultsList.css
@@ -1,7 +1,12 @@
 @import "@folio/stripes-components/lib/variables";
 
 .anchorLink {
+  width: 100%;
   font-weight: bold;
+}
+
+.anchorIcon {
+  margin-right: 5px;
 }
 
 .browseNoMatchText {

--- a/lib/SearchResultsList/SearchResultsList.js
+++ b/lib/SearchResultsList/SearchResultsList.js
@@ -103,6 +103,7 @@ const SearchResultsList = ({
               icon="exclamation-circle"
               status="error"
               iconRootClass={css.anchorLink}
+              iconClassName={css.anchorIcon}
             >
               {authority.headingRef}
               &nbsp;


### PR DESCRIPTION
## Description
Fix Long browse queries don't display properly in a not-exact match placeholder

## Screenshots
![image](https://user-images.githubusercontent.com/19309423/198585042-3665a901-fed8-46fa-9306-fbae763d26ba.png)
![image](https://user-images.githubusercontent.com/19309423/198585179-dedf2770-f6e5-46a9-91e9-b1eac1215df9.png)


## Issues
[UISAUTCOMP-22](https://issues.folio.org/browse/UISAUTCOMP-22)