### PR TITLE
UISAUTCOMP-25 Fix error when switching from "Browse" to "Search", when no records were found in the browse result list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.1.0] (IN PROGRESS)
 
 - [UISAUTCOMP-22](https://issues.folio.org/browse/UISAUTCOMP-22) Long browse queries don't display properly in a not-exact match placeholder
+- [UISAUTCOMP-25](https://issues.folio.org/browse/UISAUTCOMP-25) Fix error when switching from "Browse" to "Search", when no records were found in the browse result list
 
 ## [1.0.0] (https://github.com/folio-org/stripes-authority-components/tree/v1.0.0) (2022-10-25)
 

--- a/lib/hooks/useAutoOpenDetailView/useAutoOpenDetailView.js
+++ b/lib/hooks/useAutoOpenDetailView/useAutoOpenDetailView.js
@@ -1,4 +1,8 @@
-import { useContext, useEffect } from 'react';
+import {
+  useContext,
+  useEffect,
+} from 'react';
+
 import { navigationSegments } from '../../constants';
 import { AuthoritiesSearchContext } from '../../context';
 
@@ -11,15 +15,15 @@ const useAutoOpenDetailView = (authorities, onOpenDetailView) => {
     }
 
     const firstAuthority = authorities[0];
+
     const isDetailViewNeedsToBeOpen = navigationSegmentValue === navigationSegments.browse
       ? firstAuthority?.isAnchor && firstAuthority?.isExactMatch
-      : true;
+      : !firstAuthority?.isAnchor;
 
     if (isDetailViewNeedsToBeOpen) {
       onOpenDetailView(firstAuthority);
     }
-    // eslint-disable-next-line
-  }, [authorities, navigationSegmentValue]);
+  }, [authorities, navigationSegmentValue, onOpenDetailView]);
 };
 
 export default useAutoOpenDetailView;

--- a/lib/hooks/useAutoOpenDetailView/useAutoOpenDetailView.test.js
+++ b/lib/hooks/useAutoOpenDetailView/useAutoOpenDetailView.test.js
@@ -45,6 +45,20 @@ describe('useAutoOpenDetailView hook', () => {
       });
     });
 
+    describe('navigation segment is `search` and isAnchor is set to true', () => {
+      it('should not open detail view', () => {
+        const records = [{ isAnchor: true }];
+        const initialProps = {
+          authoritiesCtxValue: {
+            navigationSegmentValue: 'search',
+          },
+        };
+
+        renderHook(() => useAutoOpenDetailView(records, openDetailView), { wrapper, initialProps });
+        expect(openDetailView).not.toHaveBeenCalledWith(records[0]);
+      });
+    });
+
     describe('navigation segment is `browse` and isAnchor and isExactMatch are set to true', () => {
       it('should open detail view', () => {
         const records = [{ isAnchor: true, isExactMatch: true }];


### PR DESCRIPTION
## Description
When switching between Browse and Search, for a short time `authorities` array still contains Browse results, but `navigationSegment` is now `search`, so anchor result is opened.
In Search mode, only auto-open a record when it's not an anchor

## Screenshots

https://user-images.githubusercontent.com/19309423/199714766-09695f21-b21c-402d-b691-30a65af4f181.mp4


## Issues
[UISAUTCOMP-25](https://issues.folio.org/browse/UISAUTCOMP-25)