### PR TITLE
UISAUTCOMP-30: Error appears when the user executes search in "MARC Authority" app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [1.1.0] (IN PROGRESS)
 
 - [UISAUTCOMP-22](https://issues.folio.org/browse/UISAUTCOMP-22) Long browse queries don't display properly in a not-exact match placeholder
+- [UISAUTCOMP-30](https://issues.folio.org/browse/UISAUTCOMP-30) Error appears when the user executes search in "MARC Authority" app
 
 ## [1.0.1] (https://github.com/folio-org/stripes-authority-components/tree/v1.0.1) (2022-11-11)
 

--- a/lib/hooks/useAutoOpenDetailView/useAutoOpenDetailView.js
+++ b/lib/hooks/useAutoOpenDetailView/useAutoOpenDetailView.js
@@ -6,11 +6,11 @@ import {
 import { navigationSegments } from '../../constants';
 import { AuthoritiesSearchContext } from '../../context';
 
-const useAutoOpenDetailView = (authorities, onOpenDetailView) => {
+const useAutoOpenDetailView = (authorities, onOpenDetailView, doNotShowRecord) => {
   const { navigationSegmentValue } = useContext(AuthoritiesSearchContext);
 
   useEffect(() => {
-    if (authorities.length !== 1) {
+    if (authorities.length !== 1 || doNotShowRecord) {
       return;
     }
 
@@ -23,7 +23,7 @@ const useAutoOpenDetailView = (authorities, onOpenDetailView) => {
     if (isDetailViewNeedsToBeOpen) {
       onOpenDetailView(firstAuthority);
     }
-  }, [authorities, navigationSegmentValue, onOpenDetailView]);
+  }, [authorities, navigationSegmentValue, onOpenDetailView, doNotShowRecord]);
 };
 
 export default useAutoOpenDetailView;

--- a/lib/hooks/useAutoOpenDetailView/useAutoOpenDetailView.test.js
+++ b/lib/hooks/useAutoOpenDetailView/useAutoOpenDetailView.test.js
@@ -30,6 +30,21 @@ describe('useAutoOpenDetailView hook', () => {
     });
   });
 
+  describe('when doNotShowRecord is true', () => {
+    it('should not open detail view', () => {
+      const records = [{}];
+      const doNotShowRecord = true;
+      const initialProps = {
+        authoritiesCtxValue: {
+          navigationSegmentValue: 'search',
+        },
+      };
+
+      renderHook(() => useAutoOpenDetailView(records, openDetailView, doNotShowRecord), { wrapper, initialProps });
+      expect(openDetailView).not.toHaveBeenCalled();
+    });
+  });
+
   describe('when there is only one record', () => {
     describe('and navigation segment is `search`', () => {
       it('should open detail view', () => {


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIEH-57 Create example component

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
Fix constant re-rendering after doing a search with one result.
And prevent the Detail View pane from automatically opening after it is closed in marc-authority app.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color
  palette does not provide enough contrast for certain classes of
  visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIEH-57
 -->

## Issues

[UISAUTCOMP-30](https://issues.folio.org/browse/UISAUTCOMP-30)

## Related PRs
[UIPFAUTH-37](https://github.com/folio-org/ui-plugin-find-authority/pull/45)
[UIMARCAUTH-204](https://github.com/folio-org/ui-marc-authorities/pull/217)

## Screencast







https://user-images.githubusercontent.com/77053927/203527996-a1256681-629d-4c5a-bec9-58b657b0b8ad.mp4






## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 Bad:
  Made a dark color of #333, a medium color of #ccc

 Good:
   This introduces three abstract contrast levels that developers can
   use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
