### PR TITLE
UISAUTCOMP-34: 'Reset all' button doesn't return values to default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [UISAUTCOMP-22](https://issues.folio.org/browse/UISAUTCOMP-22) Long browse queries don't display properly in a not-exact match placeholder
 - [UISAUTCOMP-32](https://issues.folio.org/browse/UISAUTCOMP-32) MARC authority app: Results List: Number of titles column > Link each number to return all bib records linked to the authority record
 - [UISAUTCOMP-33](https://issues.folio.org/browse/UISAUTCOMP-33) Default search/browse option and Authority source file selections based on MARC bib field to be linked
+- [UISAUTCOMP-34](https://issues.folio.org/browse/UISAUTCOMP-34) "Reset all" button doesn't return values to default
 
 ## [1.0.2] (https://github.com/folio-org/stripes-authority-components/tree/v1.0.2) (2022-11-28)
 

--- a/lib/context/AuthoritiesSearchContext.js
+++ b/lib/context/AuthoritiesSearchContext.js
@@ -9,7 +9,6 @@ import pick from 'lodash/pick';
 
 import { buildFiltersObj } from '@folio/stripes-acq-components';
 
-import { useDidUpdate } from '../hooks';
 import {
   navigationSegments,
   searchableIndexesValues,
@@ -69,22 +68,23 @@ const AuthoritiesSearchContextProvider = ({
   const setNavigationSegmentValue = value => {
     setSearchDropdownValue(initialValues.dropdownValue || defaultDropdownValueBySegment[value]);
     setSearchIndex(initialValues.searchIndex ?? defaultDropdownValueBySegment[value]);
+    setFilters(initialValues.filters || {});
+    setSearchInputValue('');
+    setSearchQuery('');
+    setIsGoingToBaseURL(true);
+    setAdvancedSearchDefaultSearch(null);
     _setNavigationSegmentValue(value);
   };
 
   const resetAll = () => {
     setSearchInputValue('');
     setSearchQuery('');
-    setSearchDropdownValue(initialValues.dropdownValue || defaultDropdownValueBySegment[navigationSegmentValue]);
-    setSearchIndex(initialValues.searchIndex ?? defaultDropdownValueBySegment[navigationSegmentValue]);
-    setFilters(initialValues.filters || {});
+    setSearchDropdownValue(defaultDropdownValueBySegment[navigationSegmentValue]);
+    setSearchIndex(defaultDropdownValueBySegment[navigationSegmentValue]);
+    setFilters({});
     setIsGoingToBaseURL(true);
     setAdvancedSearchDefaultSearch(null);
   };
-
-  useDidUpdate(() => {
-    resetAll();
-  }, [navigationSegmentValue]);
 
   const contextValue = {
     searchInputValue,


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIEH-57 Create example component

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
After clicking the `Reset All` button the search option has to be `keyword` for `search` lookup and empty for `browse` and filters should be reset.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color
  palette does not provide enough contrast for certain classes of
  visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIEH-57
 -->
 
 ## Issues
 [UISAUTCOMP-34](https://issues.folio.org/browse/UISAUTCOMP-34)

## Screencast







https://user-images.githubusercontent.com/77053927/208935348-bb9e5c19-4911-452e-98f0-1d7ef4a6dc96.mp4







## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 Bad:
  Made a dark color of #333, a medium color of #ccc

 Good:
   This introduces three abstract contrast levels that developers can
   use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
