### PR TITLE
UISAUTCOMP-36 Ignore headingRef when filtering authorized records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [UISAUTCOMP-33](https://issues.folio.org/browse/UISAUTCOMP-33) Default search/browse option and Authority source file selections based on MARC bib field to be linked
 - [UISAUTCOMP-35](https://issues.folio.org/browse/UISAUTCOMP-35) MARC authority: Delete MARC authority record handling
 - [UISAUTCOMP-34](https://issues.folio.org/browse/UISAUTCOMP-34) "Reset all" button doesn't return values to default
+- [UISAUTCOMP-36](https://issues.folio.org/browse/UISAUTCOMP-36) Fix "Reference" record opens when user clicks on the "View" icon next to the linked "MARC Bib" field
 
 ## [1.0.2] (https://github.com/folio-org/stripes-authority-components/tree/v1.0.2) (2022-11-28)
 

--- a/lib/queries/useAuthority.js
+++ b/lib/queries/useAuthority.js
@@ -1,11 +1,14 @@
 import { useQuery } from 'react-query';
 import filter from 'lodash/filter';
+import find from 'lodash/find';
 import matches from 'lodash/matches';
 
 import {
   useOkapiKy,
   useNamespace,
 } from '@folio/stripes/core';
+
+import { AUTH_REF_TYPES } from '../constants';
 
 const AUTHORITIES_API = 'search/authorities';
 const AUTHORITY_CHUNK_SIZE = 500;
@@ -43,7 +46,14 @@ export const useAuthority = (recordId, authRefType = null, headingRef = null, { 
     },
   );
 
-  const authorityByAuthRefType = filter(data, matches({ authRefType, headingRef }))[0];
+  let authorityByAuthRefType = null;
+
+  // can only be one Authorized record - can ignore headingRef
+  if (authRefType === AUTH_REF_TYPES.AUTHORIZED) {
+    authorityByAuthRefType = find(data, matches({ authRefType }));
+  } else {
+    authorityByAuthRefType = filter(data, matches({ authRefType, headingRef }))[0];
+  }
 
   return ({
     data: authorityByAuthRefType || data[0],


### PR DESCRIPTION
## Description
Fix Reference record displaying when opening linked record

We're opening unique Authorized record, so we can ignore `headingRef` param that can be inconsistently formatted

## Screenshots

https://user-images.githubusercontent.com/19309423/211845762-ca1da83e-b56b-43a7-b3b2-6f33a1de39ec.mp4

## Issues
[UISAUTCOMP-36](https://issues.folio.org/browse/UISAUTCOMP-36)

## Related PRs
https://github.com/folio-org/ui-quick-marc/pull/427