### PR TITLE
UISAUTCOMP-38 unpin @rehooks/local-storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-authoriy-components
 
+## 2.1.0 IN PROGRESS
+
+- [UISAUTCOMP-38](https://issues.folio.org/browse/UISAUTCOMP-38) Unpin `@rehooks/local-storage` now that it's no longer broken
+
 ## [2.0.0] (https://github.com/folio-org/stripes-authority-components/tree/v2.0.0) (2023-02-13)
 
 - [UISAUTCOMP-22](https://issues.folio.org/browse/UISAUTCOMP-22) Long browse queries don't display properly in a not-exact match placeholder

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
   "dependencies": {
     "@folio/quick-marc": "^6.0.0",
     "@folio/stripes-acq-components": "~4.0.0",
-    "@rehooks/local-storage": "2.4.0",
+    "@rehooks/local-storage": "^2.4.4",
     "prop-types": "^15.6.0",
     "query-string": "^7.0.1"
   },


### PR DESCRIPTION
`@rehooks/local-storage` is no longer broken so we can once again depend on the latest version of it, allowing us to remove `resolutions` entries for it that are scattered about.

Attn @BogdanDenis I don't have commit privileges in this repository so please merge this if it looks good to you. Thanks!

Refs [UISAUTCOMP-38](https://issues.folio.org/browse/UISAUTCOMP-38)
