### PR TITLE
UISAUTCOMP-43 unpin @vue/compiler-sfc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-authoriy-components
 
+## 2.1.0 IN PROGRESS
+
+- [UISAUTCOMP-43](https://issues.folio.org/browse/UISAUTCOMP-43) Unpin `@vue/compiler-sfc` which no longer causes node conflictso
+
 ## [2.0.0] (https://github.com/folio-org/stripes-authority-components/tree/v2.0.0) (2023-02-13)
 
 - [UISAUTCOMP-22](https://issues.folio.org/browse/UISAUTCOMP-22) Long browse queries don't display properly in a not-exact match placeholder

--- a/package.json
+++ b/package.json
@@ -81,8 +81,5 @@
     "react-intl": "^5.8.0",
     "react-router": "^5.2.0",
     "react-router-dom": "^5.2.0"
-  },
-  "resolutions": {
-    "@vue/compiler-sfc": "3.2.33"
   }
 }


### PR DESCRIPTION
This package no longer causes node version conflicts and so no longer needs to be pinned.

Attn @BogdanDenis I don't have commit privileges in this repository so please merge this if it looks good to you. Thanks!

Refs [UISAUTCOMP-43](https://issues.folio.org/browse/UISAUTCOMP-43)
