### PR TITLE
UISAUTCOMP-47: Fix filtering for the `Thesaurus` facet.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [UISAUTCOMP-38](https://issues.folio.org/browse/UISAUTCOMP-38) Unpin `@rehooks/local-storage` now that it's no longer broken
 - [UISAUTCOMP-43](https://issues.folio.org/browse/UISAUTCOMP-43) Unpin `@vue/compiler-sfc` which no longer causes node conflicts
 - [UISAUTCOMP-48](https://issues.folio.org/browse/UISAUTCOMP-48) Fix imports to stripes-core
+- [UISAUTCOMP-47](https://issues.folio.org/browse/UISAUTCOMP-47) Fix filtering in the `Thesaurus` facet.
 
 ## [2.0.1] (https://github.com/folio-org/stripes-authority-components/tree/v2.0.1) (2023-03-14)
 

--- a/lib/SearchResultsList/SearchResultsList.test.js
+++ b/lib/SearchResultsList/SearchResultsList.test.js
@@ -2,7 +2,6 @@ import { render } from '@testing-library/react';
 import noop from 'lodash/noop';
 
 import { runAxeTest } from '@folio/stripes-testing';
-import { mockOffsetSize } from '@folio/stripes-acq-components/test/jest/helpers/mockOffsetSize';
 
 import Harness from '../../test/jest/helpers/harness';
 import SearchResultsList from './SearchResultsList';
@@ -63,7 +62,6 @@ const getSearchResultsList = (props = {}, selectedRecord = null) => (
 const renderSearchResultsList = (...params) => render(getSearchResultsList(...params));
 
 describe('Given SearchResultsList', () => {
-  mockOffsetSize(500, 500);
   beforeEach(() => {
     jest.clearAllMocks();
   });

--- a/lib/constants/subjectHeadingsMap.js
+++ b/lib/constants/subjectHeadingsMap.js
@@ -1,15 +1,15 @@
 import { subjectHeadingsValues } from './subjectHeadingsValues';
 
 export const subjectHeadingsMap = {
-  'a': [subjectHeadingsValues.LIBRARY_OF_CONGRESS],
-  'b': [subjectHeadingsValues.LC_FOR_CHILDRENS_LITERATURE],
-  'c': [subjectHeadingsValues.MEDICAL],
-  'd': [subjectHeadingsValues.NATIONAL_AGRICULTURE_LIBRARY],
-  'k': [subjectHeadingsValues.CANADIAN],
-  'n': [subjectHeadingsValues.NOT_APPLICABLE],
-  'r': [subjectHeadingsValues.ART_AND_ARCHITECTURE],
-  's': [subjectHeadingsValues.SEARS_LIST],
-  'v': [subjectHeadingsValues.REPERTOIRE_DE_VEDETTES_MATIERE],
-  'z': [subjectHeadingsValues.OTHER],
-  ' ': [subjectHeadingsValues.NOT_SPECIFIED],
+  'a': subjectHeadingsValues.LIBRARY_OF_CONGRESS,
+  'b': subjectHeadingsValues.LC_FOR_CHILDRENS_LITERATURE,
+  'c': subjectHeadingsValues.MEDICAL,
+  'd': subjectHeadingsValues.NATIONAL_AGRICULTURE_LIBRARY,
+  'k': subjectHeadingsValues.CANADIAN,
+  'n': subjectHeadingsValues.NOT_APPLICABLE,
+  'r': subjectHeadingsValues.ART_AND_ARCHITECTURE,
+  's': subjectHeadingsValues.SEARS_LIST,
+  'v': subjectHeadingsValues.REPERTOIRE_DE_VEDETTES_MATIERE,
+  'z': subjectHeadingsValues.OTHER,
+  ' ': subjectHeadingsValues.NOT_SPECIFIED,
 };

--- a/test/jest/__mock__/index.js
+++ b/test/jest/__mock__/index.js
@@ -6,3 +6,4 @@ import './stripesCore.mock';
 import './stripesIcon.mock';
 import './stripesSmartComponent.mock';
 import './matchMedia.mock';
+import './react-virtualized-auto-sizer.mock';

--- a/test/jest/__mock__/react-virtualized-auto-sizer.mock.js
+++ b/test/jest/__mock__/react-virtualized-auto-sizer.mock.js
@@ -1,0 +1,1 @@
+jest.mock('react-virtualized-auto-sizer', () => ({ children }) => children({ height: 500, width: 500 }));


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIEH-57 Create example component

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
Fix filtering for the `Thesaurus` facet.

Tests are failing in apps due to a recent change in `react-virtualized-auto-sizer`.
We shouldn't mock `offsetHeight` via `mockOffsetSize` because it is no longer relevant ([43](https://github.com/bvaughn/react-virtualized-auto-sizer/commit/943b6d0d4d69376f2f483201842dadbd5fc2f14d#diff-89386aae2ac82c8ec4a0d1367a57061c8abc02b01921b7db3bc139959a5778b7L163-L164)).
Just mock `react-virtualized-auto-sizer` itself.

## Issues
[UISAUTCOMP-47](https://issues.folio.org/browse/UISAUTCOMP-47)

## Screencast



https://user-images.githubusercontent.com/77053927/228242812-257e2c42-81af-4a84-abca-bf913dbc9d88.mp4



<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color
  palette does not provide enough contrast for certain classes of
  visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIEH-57
 -->

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 Bad:
  Made a dark color of #333, a medium color of #ccc

 Good:
   This introduces three abstract contrast levels that developers can
   use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
