### PR TITLE
UISAUTCOMP-56 Use formatted advanced search rows for initial search.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [UISAUTCOMP-48](https://issues.folio.org/browse/UISAUTCOMP-48) Fix imports to stripes-core
 - [UISAUTCOMP-50](https://issues.folio.org/browse/UISAUTCOMP-50) Pre-populate search/browse box with bib subfield values.
 - [UISAUTCOMP-53](https://issues.folio.org/browse/UISAUTCOMP-53) Remove redundant `records-editor.records` interface.
+- [UISAUTCOMP-56](https://issues.folio.org/browse/UISAUTCOMP-56) Use formatted advanced search rows for initial search.
 
 ## [2.0.2] (https://github.com/folio-org/stripes-authority-components/tree/v2.0.2) (2023-03-30)
 

--- a/lib/AuthoritiesSearchForm/AuthoritiesSearchForm.js
+++ b/lib/AuthoritiesSearchForm/AuthoritiesSearchForm.js
@@ -192,7 +192,7 @@ const AuthoritiesSearchForm = ({
                 </Button>
               </Col>
               {hasAdvancedSearch && (
-                <Col xs={12} sm={6}>
+                <Col xs={12} lg={6}>
                   {navigationSegmentValue !== navigationSegments.browse && (
                     <Button
                       fullWidth

--- a/lib/context/AuthoritiesSearchContext.js
+++ b/lib/context/AuthoritiesSearchContext.js
@@ -10,6 +10,7 @@ import queryString from 'query-string';
 import pick from 'lodash/pick';
 
 import { buildFiltersObj } from '@folio/stripes-acq-components';
+import { useAdvancedSearch } from '@folio/stripes/components';
 
 import {
   navigationSegments,
@@ -62,18 +63,24 @@ const AuthoritiesSearchContextProvider = ({
   const initialSearchInputValue = searchParams.query || initialValuesBySegment?.searchInputValue || '';
   const initialSearchQuery = searchParams.query || initialValuesBySegment?.searchQuery || '';
 
+
+
   const [navigationSegmentValue, _setNavigationSegmentValue] = useState(initialSegment); // eslint-disable-line react/hook-use-state
   const [searchInputValue, setSearchInputValue] = useState(initialSearchInputValue);
   const [searchQuery, setSearchQuery] = useState(initialSearchQuery);
   const [searchDropdownValue, setSearchDropdownValue] = useState(initialDropdownValue);
   const [searchIndex, setSearchIndex] = useState(initialSearchIndex);
   const [filters, setFilters] = useState(getInitialFilters());
-  const [advancedSearchRows, setAdvancedSearchRows] = useState([]);
   const [isGoingToBaseURL, setIsGoingToBaseURL] = useState(false);
   const [advancedSearchDefaultSearch, setAdvancedSearchDefaultSearch] = useState({
     query: initialSearchQuery || '',
     option: initialSearchIndex,
   });
+  const advancedSearch = useAdvancedSearch({
+    defaultSearchOptionValue: searchableIndexesValues.KEYWORD,
+    firstRowInitialSearch: advancedSearchDefaultSearch,
+  });
+  const [advancedSearchRows, setAdvancedSearchRows] = useState(advancedSearch.filledRows);
 
   useEffect(() => {
     paramsBySegment.current[initialSegment] = {


### PR DESCRIPTION
## Description
Use formatted `filledRows` and `query` from `useAdvancedSearch` hook to be used for initial search on page load without needing to open Advanced Search modal

## Screenshots

https://github.com/folio-org/stripes-components/assets/19309423/43adc3b9-c1bd-43d2-bfb0-51e77e6433e3

## Issues
[UISAUTCOMP-56](https://issues.folio.org/browse/UISAUTCOMP-56)

## Related PRs
https://github.com/folio-org/stripes-components/pull/2065