### PR TITLE
UISAUTCOMP-64 Update Node.js to v18 in GitHub Actions

### DIFF
--- a/.github/workflows/build-npm-release.yml
+++ b/.github/workflows/build-npm-release.yml
@@ -27,7 +27,7 @@ jobs:
       FOLIO_NPM_REGISTRY: 'https://repository.folio.org/repository/npm-folio/'
       FOLIO_NPM_REGISTRY_AUTH: '//repository.folio.org/repository/npm-folio/'
       FOLIO_MD_REGISTRY: 'https://folio-registry.dev.folio.org'
-      NODEJS_VERSION: '16'
+      NODEJS_VERSION: '18'
       JEST_JUNIT_OUTPUT_DIR: 'artifacts/jest-junit'
       JEST_COVERAGE_REPORT_DIR: 'artifacts/coverage-jest/lcov-report/'
       OKAPI_PULL: '{ "urls" : [ "https://folio-registry.dev.folio.org" ] }'

--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -24,7 +24,7 @@ jobs:
       FOLIO_NPM_REGISTRY: 'https://repository.folio.org/repository/npm-folioci/'
       FOLIO_NPM_REGISTRY_AUTH: '//repository.folio.org/repository/npm-folioci/'
       FOLIO_MD_REGISTRY: 'https://folio-registry.dev.folio.org'
-      NODEJS_VERSION: '16'
+      NODEJS_VERSION: '18'
       JEST_JUNIT_OUTPUT_DIR: 'artifacts/jest-junit'
       JEST_COVERAGE_REPORT_DIR: 'artifacts/coverage-jest/lcov-report/'
       SQ_LCOV_REPORT: 'artifacts/coverage-jest/lcov.info'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [UISAUTCOMP-59](https://issues.folio.org/browse/UISAUTCOMP-59) Adding authority mapping rule to mark Highlighted Fields
 - [UISAUTCOMP-62](https://issues.folio.org/browse/UISAUTCOMP-62) *BREAKING* Bump `react` to `v18`.
 - [UISAUTCOMP-63](https://issues.folio.org/browse/UISAUTCOMP-63) Add MARC authority facet for shared vs Local authority records.
+- [UISAUTCOMP-64](https://issues.folio.org/browse/UISAUTCOMP-64) Update Node.js to v18 in GitHub Actions.
 
 ## [2.0.2] (https://github.com/folio-org/stripes-authority-components/tree/v2.0.2) (2023-03-30)
 

--- a/package.json
+++ b/package.json
@@ -5,9 +5,6 @@
   "repository": "https://github.com/folio-org/stripes-authority-components",
   "main": "index.js",
   "license": "Apache-2.0",
-  "engines": {
-    "node": ">=14.0.0"
-  },
   "stripes": {
     "actsAs": [
       ""


### PR DESCRIPTION
## Description
Update Node.js to v18 in GitHub Actions

## Issues
[UISAUTCOMP-64](https://issues.folio.org/browse/UISAUTCOMP-64)