### PR TITLE
UISAUTCOMP-68 Add Shared icon to MARC authority search results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - [UISAUTCOMP-62](https://issues.folio.org/browse/UISAUTCOMP-62) *BREAKING* Bump `react` to `v18`.
 - [UISAUTCOMP-63](https://issues.folio.org/browse/UISAUTCOMP-63) Add MARC authority facet for shared vs Local authority records.
 - [UISAUTCOMP-64](https://issues.folio.org/browse/UISAUTCOMP-64) Update Node.js to v18 in GitHub Actions.
+- [UISAUTCOMP-68](https://issues.folio.org/browse/UISAUTCOMP-68) Add Shared icon to MARC authority search results.
 
 ## [2.0.2] (https://github.com/folio-org/stripes-authority-components/tree/v2.0.2) (2023-03-30)
 

--- a/lib/SharedIcon/SharedIcon.css
+++ b/lib/SharedIcon/SharedIcon.css
@@ -1,0 +1,14 @@
+.sharedIconRoot {
+  justify-content: start;
+  margin-right: var(--gutter-static-one-third);
+}
+
+.sharedIcon {
+  stroke: rgb(100, 100, 100);
+  fill: rgb(100, 100, 100);
+}
+
+.sharedIconLight {
+  stroke: rgb(255, 255, 255);
+  fill: rgb(255, 255, 255);
+}

--- a/lib/SharedIcon/SharedIcon.js
+++ b/lib/SharedIcon/SharedIcon.js
@@ -1,0 +1,47 @@
+import { useContext } from 'react';
+import PropTypes from 'prop-types';
+import { FormattedMessage } from 'react-intl';
+import classnames from 'classnames';
+
+import { Icon } from '@folio/stripes/components';
+
+import { SelectedAuthorityRecordContext } from '../context';
+
+import css from './SharedIcon.css';
+
+const propTypes = {
+  authority: PropTypes.shape({
+    headingRef: PropTypes.string.isRequired,
+    id: PropTypes.string.isRequired,
+    shared: PropTypes.bool,
+  }).isRequired,
+};
+
+const SharedIcon = ({ authority }) => {
+  const [selectedAuthorityRecord] = useContext(SelectedAuthorityRecordContext);
+  const isSelectedRecord = selectedAuthorityRecord?.id === authority.id
+    && selectedAuthorityRecord?.headingRef === authority.headingRef;
+
+  return (
+    <Icon
+      size="medium"
+      icon="graph"
+      iconRootClass={css.sharedIconRoot}
+      iconClassName={classnames(
+        css.sharedIcon,
+        { [css.sharedIconLight]: isSelectedRecord },
+      )}
+    >
+      <span
+        data-testid={`shared-icon-${authority.id}`}
+        className="sr-only"
+      >
+        <FormattedMessage id="stripes-authority-components.search.shared" />
+      </span>
+    </Icon>
+  );
+};
+
+SharedIcon.propTypes = propTypes;
+
+export { SharedIcon };

--- a/lib/SharedIcon/SharedIcon.test.js
+++ b/lib/SharedIcon/SharedIcon.test.js
@@ -1,0 +1,27 @@
+import { render } from '@folio/jest-config-stripes/testing-library/react';
+
+import { SharedIcon } from './SharedIcon';
+import Harness from '../../test/jest/helpers/harness';
+
+const authority = {
+  id: 'test-id',
+  headingRef: 'Twain, Mark',
+  shared: true,
+};
+
+const renderSharedIcon = (props = {}) => render(
+  <Harness>
+    <SharedIcon
+      authority={authority}
+      {...props}
+    />
+  </Harness>,
+);
+
+describe('SharedIcon', () => {
+  it('should render shared icon', () => {
+    const { getByText } = renderSharedIcon({ authority });
+
+    expect(getByText('stripes-authority-components.search.shared')).toBeInTheDocument();
+  });
+});

--- a/lib/SharedIcon/index.js
+++ b/lib/SharedIcon/index.js
@@ -1,0 +1,1 @@
+export * from './SharedIcon';

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,9 +10,9 @@ export * from './AuthoritiesSearchForm';
 export * from './AuthoritiesSearchPane';
 export * from './AuthoritySourceFilter';
 export * from './SubjectHeadingsFilter';
+export * from './SharedIcon';
 export * from './constants';
 export * from './hooks';
 export * from './utils';
 export * from './context';
 export * from './queries';
-


### PR DESCRIPTION
## Description
Add Shared icon to MARC authority search results

## Screenshots
![image](https://github.com/folio-org/stripes-authority-components/assets/19309423/6a1f8abb-10a4-4e13-8560-044e07d10b23)


## Issues
[UISAUTCOMP-68](https://issues.folio.org/browse/UISAUTCOMP-68)

## Related PRs