### PR TITLE
UISAUTCOMP-70 Change tenant id to central when opening details of Shared Authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 - [UISAUTCOMP-64](https://issues.folio.org/browse/UISAUTCOMP-64) Update Node.js to v18 in GitHub Actions.
 - [UISAUTCOMP-67](https://issues.folio.org/browse/UISAUTCOMP-67) Add "Local" or "Shared" to flag MARC authorities.
 - [UISAUTCOMP-68](https://issues.folio.org/browse/UISAUTCOMP-68) Add Shared icon to MARC authority search results.
+- [UISAUTCOMP-70](https://issues.folio.org/browse/UISAUTCOMP-70) Change tenant id to central when opening details of Shared Authority.
 
 ## [2.0.2] (https://github.com/folio-org/stripes-authority-components/tree/v2.0.2) (2023-03-30)
 

--- a/lib/constants/headers.js
+++ b/lib/constants/headers.js
@@ -1,0 +1,1 @@
+export const OKAPI_TENANT_HEADER = 'X-Okapi-Tenant';

--- a/lib/constants/index.js
+++ b/lib/constants/index.js
@@ -1,3 +1,4 @@
+export * from './headers';
 export * from './authRefTypes';
 export * from './browseHeadingTypesMap';
 export * from './headingTypesValues';

--- a/lib/queries/useAuthority.js
+++ b/lib/queries/useAuthority.js
@@ -3,19 +3,17 @@ import filter from 'lodash/filter';
 import find from 'lodash/find';
 import matches from 'lodash/matches';
 
-import {
-  useOkapiKy,
-  useNamespace,
-} from '@folio/stripes/core';
+import { useNamespace } from '@folio/stripes/core';
 
 import { AUTH_REF_TYPES } from '../constants';
+import { useTenantKy } from '../temp/hooks/useTenantKy';
 
 const AUTHORITIES_API = 'search/authorities';
 const AUTHORITY_CHUNK_SIZE = 500;
 
-export const useAuthority = (recordId, authRefType = null, headingRef = null, { onError }) => {
-  const ky = useOkapiKy();
+export const useAuthority = ({ recordId, tenantId, authRefType = null, headingRef = null }, { onError }) => {
   const [namespace] = useNamespace();
+  const ky = useTenantKy({ tenantId });
 
   const searchParams = {
     query: `(id==${recordId})`,

--- a/lib/queries/useAuthorityMappingRules/useAuthorityMappingRules.js
+++ b/lib/queries/useAuthorityMappingRules/useAuthorityMappingRules.js
@@ -1,18 +1,23 @@
 import { useQuery } from 'react-query';
 
-import {
-  useOkapiKy,
-  useNamespace,
-} from '@folio/stripes/core';
+import { useNamespace } from '@folio/stripes/core';
 
-const useAuthorityMappingRules = () => {
-  const ky = useOkapiKy();
+import { useTenantKy } from '../../temp/hooks/useTenantKy';
+
+const defaultArgs = {
+  enabled: true,
+};
+
+const useAuthorityMappingRules = ({ tenantId, enabled = true } = defaultArgs) => {
+  const ky = useTenantKy({ tenantId });
   const [namespace] = useNamespace({ key: 'authority-mapping-rules' });
 
   const { isFetching, data } = useQuery(
     [namespace],
     async () => {
       return ky.get('mapping-rules/marc-authority').json();
+    }, {
+      enabled,
     },
   );
 

--- a/lib/queries/useMarcSource.js
+++ b/lib/queries/useMarcSource.js
@@ -1,16 +1,14 @@
 import { useQuery } from 'react-query';
 
-import {
-  useOkapiKy,
-  useNamespace,
-} from '@folio/stripes/core';
+import { useNamespace } from '@folio/stripes/core';
 
+import { useTenantKy } from '../temp/hooks/useTenantKy';
 import { QUERY_KEY_AUTHORITY_SOURCE } from '../constants';
 
 const MARC_SOURCE_API = id => `source-storage/records/${id}/formatted?idType=AUTHORITY`;
 
-export const useMarcSource = (recordId, { onError }) => {
-  const ky = useOkapiKy();
+export const useMarcSource = ({ recordId, tenantId }, { onError }) => {
+  const ky = useTenantKy({ tenantId });
   const [namespace] = useNamespace({ key: QUERY_KEY_AUTHORITY_SOURCE });
 
   const { isFetching, data } = useQuery(

--- a/lib/temp/hooks/useTenantKy/index.js
+++ b/lib/temp/hooks/useTenantKy/index.js
@@ -1,0 +1,1 @@
+export { useTenantKy } from './useTenantKy';

--- a/lib/temp/hooks/useTenantKy/useTenantKy.js
+++ b/lib/temp/hooks/useTenantKy/useTenantKy.js
@@ -1,0 +1,19 @@
+import { useOkapiKy } from '@folio/stripes/core';
+
+import { OKAPI_TENANT_HEADER } from '../../../constants';
+
+export const useTenantKy = ({ tenantId } = {}) => {
+  const ky = useOkapiKy();
+
+  return tenantId
+    ? ky.extend({
+      hooks: {
+        beforeRequest: [
+          request => {
+            request.headers.set(OKAPI_TENANT_HEADER, tenantId);
+          },
+        ],
+      },
+    })
+    : ky;
+};

--- a/lib/temp/hooks/useTenantKy/useTenantKy.test.js
+++ b/lib/temp/hooks/useTenantKy/useTenantKy.test.js
@@ -1,0 +1,41 @@
+import { renderHook } from '@folio/jest-config-stripes/testing-library/react';
+import { useOkapiKy } from '@folio/stripes/core';
+
+import { OKAPI_TENANT_HEADER } from '../../../constants';
+import { useTenantKy } from './useTenantKy';
+
+const reqMock = {
+  headers: {
+    set: jest.fn(),
+  },
+};
+const kyMock = {
+  extend: jest.fn(({ hooks: { beforeRequest } }) => {
+    beforeRequest[0](reqMock);
+
+    return kyMock;
+  }),
+};
+
+describe('useTenantKy', () => {
+  beforeEach(() => {
+    reqMock.headers.set.mockClear();
+    kyMock.extend.mockClear();
+    useOkapiKy.mockClear().mockReturnValue(kyMock);
+  });
+
+  it('should set provided okapi tenant header and return \'ky\' client', async () => {
+    const tenantId = 'college';
+    const { result } = renderHook(() => useTenantKy({ tenantId }));
+
+    expect(result.current).toBe(kyMock);
+    expect(reqMock.headers.set).toHaveBeenCalledWith(OKAPI_TENANT_HEADER, tenantId);
+  });
+
+  it('should use current tenant in the headers if there is no provided tenant ID', async () => {
+    const { result } = renderHook(() => useTenantKy());
+
+    expect(result.current).toBe(kyMock);
+    expect(reqMock.headers.set).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Description
Change tenant id to central when opening details of Shared Authority

## Issues
[UISAUTCOMP-70](https://issues.folio.org/browse/UISAUTCOMP-70)

## Related PRs
https://github.com/folio-org/ui-marc-authorities/pull/306
https://github.com/folio-org/ui-plugin-find-authority/pull/74
https://github.com/folio-org/ui-quick-marc/pull/580