### PR TITLE
UISAUTCOMP-72: Hide the Shared facet in the plugin for the shared bib record.

### DIFF
--- a/lib/AuthoritiesSearchPane/AuthoritiesSearchPane.js
+++ b/lib/AuthoritiesSearchPane/AuthoritiesSearchPane.js
@@ -18,8 +18,7 @@ import {
 } from '../';
 
 const propTypes = {
-  excludedBrowseFilters: PropTypes.instanceOf(Set),
-  excludedSearchFilters: PropTypes.instanceOf(Set),
+  excludedFilters: PropTypes.object,
   hasAdvancedSearch: PropTypes.bool,
   height: PropTypes.string,
   isFilterPaneVisible: PropTypes.bool.isRequired,
@@ -33,6 +32,7 @@ const propTypes = {
 };
 
 const AuthoritiesSearchPane = ({
+  excludedFilters,
   isFilterPaneVisible,
   toggleFilterPane,
   isLoading,
@@ -41,8 +41,6 @@ const AuthoritiesSearchPane = ({
   query,
   hasAdvancedSearch,
   height,
-  excludedBrowseFilters,
-  excludedSearchFilters,
   tenantId,
   onShowDetailView,
 }) => {
@@ -79,7 +77,7 @@ const AuthoritiesSearchPane = ({
           ? (
             <BrowseFilters
               cqlQuery={query}
-              excludedFilters={excludedBrowseFilters}
+              excludedFilters={excludedFilters[navigationSegments.browse]}
               tenantId={tenantId}
             />
           )
@@ -87,7 +85,7 @@ const AuthoritiesSearchPane = ({
             <SearchFilters
               isSearching={isLoading}
               cqlQuery={query}
-              excludedFilters={excludedSearchFilters}
+              excludedFilters={excludedFilters[navigationSegments.search]}
               tenantId={tenantId}
             />
           )
@@ -98,8 +96,7 @@ const AuthoritiesSearchPane = ({
 
 AuthoritiesSearchPane.propTypes = propTypes;
 AuthoritiesSearchPane.defaultProps = {
-  excludedBrowseFilters: new Set(),
-  excludedSearchFilters: new Set(),
+  excludedFilters: {},
   resetSelectedRows: noop,
   hasAdvancedSearch: false,
   height: null,

--- a/lib/AuthoritiesSearchPane/AuthoritiesSearchPane.test.js
+++ b/lib/AuthoritiesSearchPane/AuthoritiesSearchPane.test.js
@@ -32,8 +32,6 @@ const renderAuthoritiesSearchPane = (props = {}) => render(
       hasAdvancedSearch
       query=""
       toggleFilterPane={mockToggleFilterPane}
-      excludedBrowseFilters={new Set()}
-      excludedSearchFilters={new Set()}
       {...props}
     />
   </Harness>,

--- a/lib/BrowseFilters/BrowseFilters.js
+++ b/lib/BrowseFilters/BrowseFilters.js
@@ -21,7 +21,7 @@ import {
 
 const propTypes = {
   cqlQuery: PropTypes.string,
-  excludedFilters: PropTypes.instanceOf(Set),
+  excludedFilters: PropTypes.arrayOf(PropTypes.string),
   tenantId: PropTypes.string,
 };
 
@@ -56,7 +56,7 @@ const BrowseFilters = ({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const isVisible = filter => !excludedFilters.has(filter);
+  const isVisible = filter => !excludedFilters.includes(filter);
 
   return (
     <>
@@ -117,7 +117,7 @@ BrowseFilters.propTypes = propTypes;
 
 BrowseFilters.defaultProps = {
   cqlQuery: '',
-  excludedFilters: new Set(),
+  excludedFilters: [],
   tenantId: '',
 };
 

--- a/lib/BrowseFilters/BrowseFilters.test.js
+++ b/lib/BrowseFilters/BrowseFilters.test.js
@@ -86,7 +86,7 @@ describe('Given BrowseFilters', () => {
   describe('when there are excluded filters', () => {
     it('should display only non-excluded filters', () => {
       const { queryByText, getByText } = renderBrowseFilters({
-        excludedFilters: new Set([FILTERS.REFERENCES]),
+        excludedFilters: [FILTERS.REFERENCES],
       });
 
       expect(queryByText('stripes-authority-components.search.references')).not.toBeInTheDocument();

--- a/lib/SearchFilters/SearchFilters.js
+++ b/lib/SearchFilters/SearchFilters.js
@@ -26,7 +26,7 @@ const DATE_FORMAT = 'YYYY-MM-DD';
 
 const propTypes = {
   cqlQuery: PropTypes.string,
-  excludedFilters: PropTypes.instanceOf(Set),
+  excludedFilters: PropTypes.arrayOf(PropTypes.string),
   isSearching: PropTypes.bool.isRequired,
   tenantId: PropTypes.string,
 };
@@ -64,7 +64,7 @@ const SearchFilters = ({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  const isVisible = filter => !excludedFilters.has(filter);
+  const isVisible = filter => !excludedFilters.includes(filter);
 
   return (
     <>
@@ -160,7 +160,7 @@ SearchFilters.propTypes = propTypes;
 
 SearchFilters.defaultProps = {
   cqlQuery: '',
-  excludedFilters: new Set(),
+  excludedFilters: [],
   tenantId: '',
 };
 

--- a/lib/SearchFilters/SearchFilters.test.js
+++ b/lib/SearchFilters/SearchFilters.test.js
@@ -105,7 +105,7 @@ describe('Given SearchFilters', () => {
   describe('when there are excluded filters', () => {
     it('should display only non-excluded filters', () => {
       const { queryByText, getByText } = renderSearchFilters({
-        excludedFilters: new Set([FILTERS.REFERENCES]),
+        excludedFilters: [FILTERS.REFERENCES],
       });
 
       expect(queryByText('stripes-authority-components.search.references')).not.toBeInTheDocument();


### PR DESCRIPTION

<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIEH-57 Create example component

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
Hide the Shared facet in the plugin for the shared bib record.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color
  palette does not provide enough contrast for certain classes of
  visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIEH-57
 -->

## Related PRs
https://github.com/folio-org/ui-quick-marc/pull/585
https://github.com/folio-org/ui-plugin-find-authority/pull/76

## Issue
[UISAUTCOMP-72](https://issues.folio.org/browse/UISAUTCOMP-72)
## Screencast


https://github.com/folio-org/stripes-authority-components/assets/77053927/352a1b23-c0bf-41a8-8f84-accbd24afccd



## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 Bad:
  Made a dark color of #333, a medium color of #ccc

 Good:
   This introduces three abstract contrast levels that developers can
   use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Screenshots
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
