### PR TITLE
UISAUTCOMP-74 Shared MARC authority doesn't open automatically on Member tenant when search returns one record.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - [UISAUTCOMP-70](https://issues.folio.org/browse/UISAUTCOMP-70) Change tenant id to central when opening details of Shared Authority.
 - [UISAUTCOMP-72](https://issues.folio.org/browse/UISAUTCOMP-72) Link Shared/Local MARC bib record to Shared/Local Authority record.
 - [UISAUTCOMP-73](https://issues.folio.org/browse/UISAUTCOMP-73) Delete Shared MARC authority record.
+- [UISAUTCOMP-74](https://issues.folio.org/browse/UISAUTCOMP-74) Shared "MARC authority" doesn't open automatically on "Member" tenant when search returns one record.
 
 ## [2.0.2] (https://github.com/folio-org/stripes-authority-components/tree/v2.0.2) (2023-03-30)
 

--- a/lib/queries/useMarcSource.js
+++ b/lib/queries/useMarcSource.js
@@ -7,7 +7,7 @@ import { QUERY_KEY_AUTHORITY_SOURCE } from '../constants';
 
 const MARC_SOURCE_API = id => `source-storage/records/${id}/formatted?idType=AUTHORITY`;
 
-export const useMarcSource = ({ recordId, tenantId }, { onError }) => {
+export const useMarcSource = ({ recordId, tenantId, enabled = true }, { onError }) => {
   const ky = useTenantKy({ tenantId });
   const [namespace] = useNamespace({ key: QUERY_KEY_AUTHORITY_SOURCE });
 
@@ -16,6 +16,8 @@ export const useMarcSource = ({ recordId, tenantId }, { onError }) => {
     async () => {
       return ky.get(MARC_SOURCE_API(recordId)).json()
         .catch(onError);
+    }, {
+      enabled,
     },
   );
 


### PR DESCRIPTION
## Description
Shared MARC authority doesn't open automatically on Member tenant when search returns one record.
MARC Authorities app will enable the request when authority record is loaded

## Issues
[UISAUTCOMP-74](https://issues.folio.org/browse/UISAUTCOMP-74)