### PR TITLE
UISAUTCOMP-77 Use "see from also" options for Name-Title search.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 - [UISAUTCOMP-73](https://issues.folio.org/browse/UISAUTCOMP-73) Delete Shared MARC authority record.
 - [UISAUTCOMP-74](https://issues.folio.org/browse/UISAUTCOMP-74) Shared "MARC authority" doesn't open automatically on "Member" tenant when search returns one record.
 - [UISAUTCOMP-76](https://issues.folio.org/browse/UISAUTCOMP-76) *BREAKING* bump `react-intl` to `v6.4.4`.
+- [UISAUTCOMP-77](https://issues.folio.org/browse/UISAUTCOMP-77) Use "see from also" options for Name-Title search.
 
 ## [2.0.2] (https://github.com/folio-org/stripes-authority-components/tree/v2.0.2) (2023-03-30)
 

--- a/lib/constants/searchableIndexesMap.js
+++ b/lib/constants/searchableIndexesMap.js
@@ -40,14 +40,17 @@ export const searchableIndexesMap = {
     name: 'personalNameTitle',
     plain: true,
     sft: true,
+    saft: true,
   }, {
     name: 'corporateNameTitle',
     plain: true,
     sft: true,
+    saft: true,
   }, {
     name: 'meetingNameTitle',
     plain: true,
     sft: true,
+    saft: true,
   }],
   [searchableIndexesValues.UNIFORM_TITLE]: [{
     name: 'uniformTitle',


### PR DESCRIPTION
## Description
Fix User cannot find "MARC authority" record by "5XX" field using "Name-title" search option.
Use `saft` for Name-Title search options

## Screenshots

https://github.com/folio-org/stripes-authority-components/assets/19309423/da50c11e-1dd2-4229-b111-5bb77580524b



## Issues
[UISAUTCOMP-77](https://issues.folio.org/browse/UISAUTCOMP-77)