### PR TITLE
UISAUTCOMP-79: Fix the Next button being disabled when moving from the second page to the first and focusing the first row of the list only after loading the data.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - [UISAUTCOMP-76](https://issues.folio.org/browse/UISAUTCOMP-76) *BREAKING* bump `react-intl` to `v6.4.4`.
 - [UISAUTCOMP-77](https://issues.folio.org/browse/UISAUTCOMP-77) Use "see from also" options for Name-Title search.
 - [UISAUTCOMP-78](https://issues.folio.org/browse/UISAUTCOMP-78) Don't clear previous Search/Browse results to highlight the edited record.
+- [UISAUTCOMP-79](https://issues.folio.org/browse/UISAUTCOMP-79) Fix the Next button being disabled when moving from the second page to the first and focusing the first row of the list only after loading the data.
 
 ## [2.0.2] (https://github.com/folio-org/stripes-authority-components/tree/v2.0.2) (2023-03-30)
 

--- a/lib/SearchResultsList/SearchResultsList.js
+++ b/lib/SearchResultsList/SearchResultsList.js
@@ -43,7 +43,6 @@ const propTypes = {
   onNeedMoreData: PropTypes.func.isRequired,
   onRowFocus: PropTypes.func,
   pageSize: PropTypes.number.isRequired,
-  pagingOffset: PropTypes.number,
   query: PropTypes.string.isRequired,
   renderHeadingRef: PropTypes.func.isRequired,
   sortedColumn: PropTypes.string,
@@ -62,7 +61,6 @@ const SearchResultsList = ({
   loading,
   loaded,
   pageSize,
-  pagingOffset,
   onNeedMoreData,
   visibleColumns,
   sortedColumn,
@@ -162,7 +160,6 @@ const SearchResultsList = ({
       isSelected={checkIsRowSelected}
       onRowClick={onRowClick}
       totalCount={totalResults}
-      pagingOffset={pagingOffset}
       pagingType="prev-next"
       pageAmount={pageSize}
       loading={loading}
@@ -211,7 +208,6 @@ SearchResultsList.defaultProps = {
   itemToView: null,
   onRowFocus: null,
   onHeaderClick: null,
-  pagingOffset: undefined, // undefined is required
   sortedColumn: null,
   sortOrder: null,
   totalResults: NaN,

--- a/lib/queries/useAuthorities/useAuthorities.js
+++ b/lib/queries/useAuthorities/useAuthorities.js
@@ -137,6 +137,9 @@ const useAuthorities = ({
     }, {
       enabled: !(!searchQuery && !Object.values(filters).find(value => value.length > 0)),
       keepPreviousData: true,
+      // cacheTime must be 0 so that the `Next` button isn't disabled after we return to the first page from the second,
+      // and also the `offset` (empty items) should be added to the `authorities` array only after new data is loaded.
+      cacheTime: 0,
     },
   );
 
@@ -146,8 +149,10 @@ const useAuthorities = ({
     authoritiesArray.splice(offset, 0, ...data?.authorities || []);
 
     return authoritiesArray;
+    // Don't add `offset` to deps, it will focus the first row prematurely
+    // and disable the `Next` button after we return to the first page from the second.
     // eslint-disable-next-line
-  }, [data?.authorities, offset]);
+  }, [data?.authorities]);
 
   return ({
     totalRecords: data?.totalRecords || 0,

--- a/lib/queries/useAuthoritiesBrowse/useAuthoritiesBrowse.js
+++ b/lib/queries/useAuthoritiesBrowse/useAuthoritiesBrowse.js
@@ -68,6 +68,7 @@ const useBrowseRequest = ({
     }, {
       enabled: !(!searchQuery && !Object.values(filters).find(value => value.length > 0)),
       keepPreviousData: true,
+      cacheTime: 0, // allows us to not move to the first row until the data is loaded
     },
   );
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIEH-57 Create example component

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
Fix the Next button being disabled when moving from the second page to the first and focusing the first row of the list only after loading the data.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color
  palette does not provide enough contrast for certain classes of
  visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIEH-57
 -->
## Issue
[UISAUTCOMP-79](https://issues.folio.org/browse/UISAUTCOMP-79)

## Related PRs
https://github.com/folio-org/ui-marc-authorities/pull/317
https://github.com/folio-org/ui-plugin-find-authority/pull/79
https://github.com/folio-org/stripes-components/pull/2126

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 Bad:
  Made a dark color of #333, a medium color of #ccc

 Good:
   This introduces three abstract contrast levels that developers can
   use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Screenshots


https://github.com/folio-org/stripes-authority-components/assets/77053927/6b998cfa-c0ca-44d1-9e33-e36f96e1bfdd






<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
