### PR TITLE
UISAUTCOMP-84  Fix "Reset all" button doesn't reset result pane in "MARC authority" app.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@
 - [UISAUTCOMP-77](https://issues.folio.org/browse/UISAUTCOMP-77) Use "see from also" options for Name-Title search.
 - [UISAUTCOMP-78](https://issues.folio.org/browse/UISAUTCOMP-78) Don't clear previous Search/Browse results to highlight the edited record.
 - [UISAUTCOMP-79](https://issues.folio.org/browse/UISAUTCOMP-79) Fix the Next button being disabled when moving from the second page to the first and focusing the first row of the list only after loading the data.
+- [UISAUTCOMP-84](https://issues.folio.org/browse/UISAUTCOMP-84) Fix "Reset all" button doesn't reset result pane in "MARC authority" app.
 
 ## [2.0.2] (https://github.com/folio-org/stripes-authority-components/tree/v2.0.2) (2023-03-30)
 

--- a/lib/queries/useAuthorities/useAuthorities.js
+++ b/lib/queries/useAuthorities/useAuthorities.js
@@ -131,11 +131,14 @@ const useAuthorities = ({
   } = useQuery(
     [namespace, searchParams],
     () => {
+      if (!searchQuery && !Object.values(filters).find(value => value.length > 0)) {
+        return { authorities: [], totalRecords: 0 };
+      }
+
       const path = `${AUTHORITIES_API}?${queryString.stringify(searchParams)}`.replace(/\+/g, '%20');
 
       return ky.get(path).json();
     }, {
-      enabled: !(!searchQuery && !Object.values(filters).find(value => value.length > 0)),
       keepPreviousData: true,
       // cacheTime: 0 should not be applied. Previous data is used in the useHighlightEditedRecord.
     },

--- a/lib/queries/useAuthoritiesBrowse/useAuthoritiesBrowse.js
+++ b/lib/queries/useAuthoritiesBrowse/useAuthoritiesBrowse.js
@@ -62,11 +62,14 @@ const useBrowseRequest = ({
   } = useQuery(
     [namespace, 'authorities', searchParams],
     () => {
+      if (!searchQuery && !Object.values(filters).find(value => value.length > 0)) {
+        return { authorities: [], totalRecords: 0 };
+      }
+
       const path = `${AUTHORITIES_BROWSE_API}?${queryString.stringify(searchParams)}`.replace(/\+/g, '%20');
 
       return ky.get(path).json();
     }, {
-      enabled: !(!searchQuery && !Object.values(filters).find(value => value.length > 0)),
       keepPreviousData: true,
       cacheTime: 0, // allows us to not move to the first row until the data is loaded
     },


### PR DESCRIPTION
## Description
Fix "Reset all" button doesn't reset result pane in "MARC authority" app.

## Screenshots

https://github.com/folio-org/stripes-authority-components/assets/19309423/42ed8544-5753-4832-84f0-0aa719348d68

## Issues
[UISAUTCOMP-84](https://issues.folio.org/browse/UISAUTCOMP-84)