### PR TITLE
Remove ui-quick-marc dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "regenerator-runtime": "^0.13.3"
   },
   "dependencies": {
-    "@folio/quick-marc": "^7.0.0",
     "@folio/stripes-acq-components": "^5.0.0",
     "@rehooks/local-storage": "^2.4.4",
     "classnames": "^2.3.2",


### PR DESCRIPTION
There is a circular dependency between `stripes-authority-components`, `ui-plugin-find-authority` and `ui-quick-marc` which blocks releasing all three modules
`ui-quick-marc` depends on `ui-plugin-find-authority`, which depends on `stripes-authority-components`, which in turn has `ui-quick-marc` dependency.
Thankfully, `ui-quick-marc` is not used anywhere in code - it was just listed as a dep, so we only need to update `package.json`