### PR TITLE
UISAUTCOMP-93: Add new column called Authority source for browse and search results.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [UISAUTCOMP-65](https://issues.folio.org/browse/UISAUTCOMP-65) Remove eslint deps that are already listed in eslint-config-stripes.
 - [UISAUTCOMP-91](https://issues.folio.org/browse/UISAUTCOMP-91) Add LCCN search option.
 - [UISAUTCOMP-92](https://issues.folio.org/browse/UISAUTCOMP-92) Search box/Browse box- Reset all should shift focus back to search box.
+- [UISAUTCOMP-93](https://issues.folio.org/browse/UISAUTCOMP-93) Add new column called Authority source for browse and search results.
 
 ## [3.0.1] (https://github.com/folio-org/stripes-authority-components/tree/v3.0.1) (2023-10-27)
 

--- a/lib/SearchResultsList/SearchResultsList.js
+++ b/lib/SearchResultsList/SearchResultsList.js
@@ -85,16 +85,23 @@ const SearchResultsList = ({
   const { sourceFiles } = useAuthoritySourceFiles();
 
   const defaultFormatter = {
-    [searchResultListColumns.AUTH_REF_TYPE]: authority => {
-      return authority.authRefType === AUTH_REF_TYPES.AUTHORIZED
-        ? <b>{authority.authRefType}</b>
-        : authority.authRefType;
+    // eslint-disable-next-line react/no-multi-comp, react/prop-types
+    [searchResultListColumns.AUTH_REF_TYPE]: ({ authRefType }) => {
+      return authRefType === AUTH_REF_TYPES.AUTHORIZED
+        ? <b>{authRefType}</b>
+        : authRefType;
     },
+    // eslint-disable-next-line react/no-multi-comp
     [searchResultListColumns.HEADING_REF]: authority => {
-      const anchorLink = authority.isAnchor ? css.anchorLink : undefined;
+      const {
+        isAnchor,
+        isExactMatch,
+        headingRef,
+      } = authority;
+      const anchorLink = isAnchor ? css.anchorLink : undefined;
 
       return (
-        authority.isAnchor && !authority.isExactMatch
+        isAnchor && !isExactMatch
           ? (
             <span>
               <Icon
@@ -103,7 +110,7 @@ const SearchResultsList = ({
                 iconRootClass={css.anchorLink}
               />
               <span className={css.noMatchLabelWrapper}>
-                {authority.headingRef}
+                {headingRef}
                 &ensp;
                 <span className={css.browseNoMatchText}>
                   {intl.formatMessage({ id: 'stripes-authority-components.browse.noMatch.wouldBeHereLabel' })}

--- a/lib/SearchResultsList/SearchResultsList.js
+++ b/lib/SearchResultsList/SearchResultsList.js
@@ -12,6 +12,7 @@ import {
 } from '@folio/stripes/components';
 import { SearchAndSortNoResultsMessage } from '@folio/stripes/smart-components';
 
+import { useAuthoritySourceFiles } from '../queries';
 import { SelectedAuthorityRecordContext } from '../context';
 import { areRecordsEqual } from './utils';
 import {
@@ -58,7 +59,7 @@ const SearchResultsList = ({
   columnMapping,
   formatter,
   totalResults,
-  loading,
+  loading: isLoadingAuthorities,
   loaded,
   pageSize,
   onNeedMoreData,
@@ -81,19 +82,17 @@ const SearchResultsList = ({
   const intl = useIntl();
   const [selectedAuthorityRecord, setSelectedAuthorityRecord] = useContext(SelectedAuthorityRecordContext);
 
-  const defaultColumnMapping = {
-    [searchResultListColumns.AUTH_REF_TYPE]: intl.formatMessage({ id: 'stripes-authority-components.search-results-list.authRefType' }),
-    [searchResultListColumns.HEADING_REF]: intl.formatMessage({ id: 'stripes-authority-components.search-results-list.headingRef' }),
-    [searchResultListColumns.HEADING_TYPE]: intl.formatMessage({ id: 'stripes-authority-components.search-results-list.headingType' }),
-  };
+  const { sourceFiles, isLoading: isLoadingSourceFiles } = useAuthoritySourceFiles();
+
+  const loading = isLoadingAuthorities || isLoadingSourceFiles;
 
   const defaultFormatter = {
-    authRefType: authority => {
+    [searchResultListColumns.AUTH_REF_TYPE]: authority => {
       return authority.authRefType === AUTH_REF_TYPES.AUTHORIZED
         ? <b>{authority.authRefType}</b>
         : authority.authRefType;
     },
-    headingRef: authority => {
+    [searchResultListColumns.HEADING_REF]: authority => {
       const anchorLink = authority.isAnchor ? css.anchorLink : undefined;
 
       return (
@@ -116,6 +115,9 @@ const SearchResultsList = ({
           )
           : renderHeadingRef(authority, anchorLink)
       );
+    },
+    [searchResultListColumns.AUTHORITY_SOURCE]: ({ sourceFileId }) => {
+      return sourceFiles.find(sourceFile => sourceFile.id === sourceFileId)?.name;
     },
   };
 
@@ -143,10 +145,7 @@ const SearchResultsList = ({
   return (
     <MultiColumnList
       hasMargin
-      columnMapping={{
-        ...defaultColumnMapping,
-        ...columnMapping,
-      }}
+      columnMapping={columnMapping}
       columnWidths={columnWidths}
       contentData={authorities}
       formatter={{

--- a/lib/SearchResultsList/SearchResultsList.js
+++ b/lib/SearchResultsList/SearchResultsList.js
@@ -59,7 +59,7 @@ const SearchResultsList = ({
   columnMapping,
   formatter,
   totalResults,
-  loading: isLoadingAuthorities,
+  loading,
   loaded,
   pageSize,
   onNeedMoreData,
@@ -82,9 +82,7 @@ const SearchResultsList = ({
   const intl = useIntl();
   const [selectedAuthorityRecord, setSelectedAuthorityRecord] = useContext(SelectedAuthorityRecordContext);
 
-  const { sourceFiles, isLoading: isLoadingSourceFiles } = useAuthoritySourceFiles();
-
-  const loading = isLoadingAuthorities || isLoadingSourceFiles;
+  const { sourceFiles } = useAuthoritySourceFiles();
 
   const defaultFormatter = {
     [searchResultListColumns.AUTH_REF_TYPE]: authority => {

--- a/lib/SearchResultsList/SearchResultsList.test.js
+++ b/lib/SearchResultsList/SearchResultsList.test.js
@@ -31,6 +31,27 @@ jest.mock('react-router', () => ({
   useRouteMatch: jest.fn().mockReturnValue({ path: '' }),
 }));
 
+jest.mock('../queries', () => ({
+  ...jest.requireActual('../queries'),
+  useAuthoritySourceFiles: jest.fn().mockReturnValue({
+    isLoading: false,
+    sourceFiles: [{
+      id: '4b531a84-d4fe-44e5-b75f-542ec71b2f62',
+      name: 'LC Demographic Group Terms (LCFGT)',
+    }, {
+      id: 'af045f2f-e851-4613-984c-4bc13430333a',
+      name: 'STAFF_source',
+    }],
+  }),
+}));
+
+const columnMapping = {
+  [searchResultListColumns.AUTH_REF_TYPE]: 'stripes-authority-components.search-results-list.authRefType',
+  [searchResultListColumns.HEADING_REF]: 'stripes-authority-components.search-results-list.headingRef',
+  [searchResultListColumns.AUTHORITY_SOURCE]: 'stripes-authority-components.search-results-list.authoritySource',
+  [searchResultListColumns.HEADING_TYPE]: 'stripes-authority-components.search-results-list.headingType',
+};
+
 const getSearchResultsList = (props = {}, selectedRecord = null) => (
   <Harness selectedRecordCtxValue={[selectedRecord, mockSetSelectedAuthorityRecordContext]}>
     <SearchResultsList
@@ -39,7 +60,9 @@ const getSearchResultsList = (props = {}, selectedRecord = null) => (
         searchResultListColumns.AUTH_REF_TYPE,
         searchResultListColumns.HEADING_REF,
         searchResultListColumns.HEADING_TYPE,
+        searchResultListColumns.AUTHORITY_SOURCE,
       ]}
+      columnMapping={columnMapping}
       totalResults={authorities.length}
       loading={false}
       loaded={false}
@@ -80,12 +103,13 @@ describe('Given SearchResultsList', () => {
     });
   });
 
-  it('should display 3 columns', () => {
-    const { getByText } = renderSearchResultsList();
+  it('should display columns', () => {
+    const { getByRole } = renderSearchResultsList();
 
-    expect(getByText('stripes-authority-components.search-results-list.authRefType')).toBeDefined();
-    expect(getByText('stripes-authority-components.search-results-list.headingRef')).toBeDefined();
-    expect(getByText('stripes-authority-components.search-results-list.headingType')).toBeDefined();
+    expect(getByRole('columnheader', { name: 'stripes-authority-components.search-results-list.authRefType' })).toBeVisible();
+    expect(getByRole('columnheader', { name: 'stripes-authority-components.search-results-list.headingRef' })).toBeVisible();
+    expect(getByRole('columnheader', { name: 'stripes-authority-components.search-results-list.headingType' })).toBeVisible();
+    expect(getByRole('columnheader', { name: 'stripes-authority-components.search-results-list.authoritySource' })).toBeVisible();
   });
 
   it('should display empty message', () => {
@@ -205,12 +229,7 @@ describe('Given SearchResultsList', () => {
 
       fireEvent.click(getByText('Auth/Ref'));
 
-      expect(mockSetSelectedAuthorityRecordContext).toHaveBeenCalledWith({
-        id: '5a404f5d-2c46-4426-9f28-db8d26881b30',
-        headingType: 'Personal name',
-        authRefType: 'Auth/Ref',
-        headingRef: 'Twain, Mark',
-      });
+      expect(mockSetSelectedAuthorityRecordContext).toHaveBeenCalledWith(authorities[0]);
     });
   });
 
@@ -223,5 +242,12 @@ describe('Given SearchResultsList', () => {
 
       expect(mockSetSelectedAuthorityRecordContext).not.toHaveBeenCalled();
     });
+  });
+
+  it('should display authority sources in the list', () => {
+    const { getByText } = renderSearchResultsList({ authorities: authorities.slice(0, 2) });
+
+    expect(getByText('LC Demographic Group Terms (LCFGT)')).toBeDefined();
+    expect(getByText('STAFF_source')).toBeDefined();
   });
 });

--- a/lib/constants/searchResultsListColumns.js
+++ b/lib/constants/searchResultsListColumns.js
@@ -5,4 +5,5 @@ export const searchResultListColumns = {
   HEADING_TYPE: 'headingType',
   LINK: 'link',
   NUMBER_OF_TITLES: 'numberOfTitles',
+  AUTHORITY_SOURCE: 'authoritySource',
 };

--- a/mocks/authorities.json
+++ b/mocks/authorities.json
@@ -2,11 +2,13 @@
   "id": "5a404f5d-2c46-4426-9f28-db8d26881b30",
   "headingType": "Personal name",
   "authRefType": "Auth/Ref",
+  "sourceFileId": "4b531a84-d4fe-44e5-b75f-542ec71b2f62",
   "headingRef": "Twain, Mark"
 }, {
   "id": "4a76b9e5-ff5f-45c6-b8c8-6b27c57a0812",
   "headingType": "Personal name",
   "authRefType": "Reference",
+  "sourceFileId": "af045f2f-e851-4613-984c-4bc13430333a",
   "headingRef": "Twain, Mark"
 }, {
   "id": "1eee9b1d-0dc6-4272-8481-367ec71e1ea5",

--- a/translations/stripes-authority-components/en.json
+++ b/translations/stripes-authority-components/en.json
@@ -41,6 +41,7 @@
   "search-results-list.authRefType": "Authorized/Reference",
   "search-results-list.headingRef": "Heading/Reference",
   "search-results-list.headingType": "Type of heading",
+  "search-results-list.authoritySource": "Authority source",
   "search-results-list.paneSub": "{totalRecords, number} {totalRecords, plural, one {record found} other {records found}}",
   "search-results-list.selectAll": "Unselect all records on this page",
   "search-results-list.unselectAll": "Select all records on this page",


### PR DESCRIPTION
## Purpose
Add a new column called `Authority source` for the browse and search results.

## Issues
[UISAUTCOMP-93](https://issues.folio.org/browse/UISAUTCOMP-93)

## Related PRs
https://github.com/folio-org/ui-plugin-find-authority/pull/86
https://github.com/folio-org/ui-marc-authorities/pull/328

## Screencast

https://github.com/folio-org/ui-plugin-find-authority/assets/77053927/bff2f1fc-c3db-4f80-b907-2ca0effa6978

