### PR TITLE
UISAUTCOMP-94 MARC authority - Keyword search should search natural id.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [UISAUTCOMP-65](https://issues.folio.org/browse/UISAUTCOMP-65) Remove eslint deps that are already listed in eslint-config-stripes.
 - [UISAUTCOMP-91](https://issues.folio.org/browse/UISAUTCOMP-91) Add LCCN search option.
 - [UISAUTCOMP-92](https://issues.folio.org/browse/UISAUTCOMP-92) Search box/Browse box- Reset all should shift focus back to search box.
+- [UISAUTCOMP-94](https://issues.folio.org/browse/UISAUTCOMP-94) MARC authority - Keyword search should search natural id.
 
 ## [3.0.1] (https://github.com/folio-org/stripes-authority-components/tree/v3.0.1) (2023-10-27)
 

--- a/lib/queries/useAuthorities/useAuthorities.test.js
+++ b/lib/queries/useAuthorities/useAuthorities.test.js
@@ -86,7 +86,7 @@ describe('Given useAuthorities', () => {
 
         await act(async () => !result.current.isLoading);
 
-        expect(result.current.query).toEqual('(keyword=="test") sortBy authRefType/sort.descending');
+        expect(result.current.query).toEqual('(keyword=="test" or naturalId="test") sortBy authRefType/sort.descending');
       });
     });
 
@@ -105,7 +105,7 @@ describe('Given useAuthorities', () => {
 
         await act(async () => !result.current.isLoading);
 
-        expect(result.current.query).toEqual('(keyword=="test") sortBy authRefType/sort.ascending');
+        expect(result.current.query).toEqual('(keyword=="test" or naturalId="test") sortBy authRefType/sort.ascending');
       });
     });
   });
@@ -179,7 +179,7 @@ describe('Given useAuthorities', () => {
       });
 
       expect(result_.current.query).toBe(
-        '(keyword=="advancedTest1") not ((identifiers.value=="advancedTest2" or naturalId="advancedTest2") and authRefType=="Authorized")',
+        '(keyword=="advancedTest1" or naturalId="advancedTest1") not ((identifiers.value=="advancedTest2" or naturalId="advancedTest2") and authRefType=="Authorized")',
       );
     });
 

--- a/lib/queries/utils/buildQuery.js
+++ b/lib/queries/utils/buildQuery.js
@@ -24,10 +24,14 @@ const buildQuery = ({
     return '';
   }
 
+  if (searchIndex === searchableIndexesValues.KEYWORD) {
+    return `(${searchableIndexesValues.KEYWORD}=="%{query}" or naturalId="%{query}")`;
+  }
+
   if (searchIndex === searchableIndexesValues.CHILDREN_SUBJECT_HEADING) {
     const childrenSubjectHeadingData = indexData[0];
 
-    return `(${searchableIndexesValues.KEYWORD}=="%{query}" and ${childrenSubjectHeadingData.name}=="b")`;
+    return `((${searchableIndexesValues.KEYWORD}=="%{query}" or naturalId="%{query}") and ${childrenSubjectHeadingData.name}=="b")`;
   }
 
   if (searchIndex === searchableIndexesValues.IDENTIFIER) {

--- a/lib/queries/utils/buildQuery.test.js
+++ b/lib/queries/utils/buildQuery.test.js
@@ -46,7 +46,7 @@ describe('Given buildQuery', () => {
         query: 'somevalue',
       });
 
-      expect(query).toBe('(keyword=="%{query}")');
+      expect(query).toBe('(keyword=="%{query}" or naturalId="%{query}")');
     });
   });
 
@@ -113,7 +113,7 @@ describe('Given buildQuery', () => {
         query: 'somevalue',
       });
 
-      expect(query).toBe('(keyword=="%{query}" and subjectHeadings=="b")');
+      expect(query).toBe('((keyword=="%{query}" or naturalId="%{query}") and subjectHeadings=="b")');
     });
   });
 


### PR DESCRIPTION
## Description
keyword and children's subject headings search should also search by `naturalId` field

## Screenshots

https://github.com/folio-org/stripes-authority-components/assets/19309423/638ace69-5b9b-43f2-b245-3e5937059052

## Issues
[UISAUTCOMP-94](https://issues.folio.org/browse/UISAUTCOMP-94)