### PR TITLE
UISAUTCOMP-93 follow-up: Show 'Not specified' when authority does not have a source file

### DIFF
--- a/lib/SearchResultsList/SearchResultsList.js
+++ b/lib/SearchResultsList/SearchResultsList.js
@@ -122,7 +122,8 @@ const SearchResultsList = ({
       );
     },
     [searchResultListColumns.AUTHORITY_SOURCE]: ({ sourceFileId }) => {
-      return sourceFiles.find(sourceFile => sourceFile.id === sourceFileId)?.name;
+      return sourceFiles.find(sourceFile => sourceFile.id === sourceFileId)?.name
+        || intl.formatMessage({ id: 'stripes-authority-components.search.sourceFileId.nullOption' });
     },
   };
 

--- a/lib/SearchResultsList/SearchResultsList.test.js
+++ b/lib/SearchResultsList/SearchResultsList.test.js
@@ -245,9 +245,10 @@ describe('Given SearchResultsList', () => {
   });
 
   it('should display authority sources in the list', () => {
-    const { getByText } = renderSearchResultsList({ authorities: authorities.slice(0, 2) });
+    const { getByText } = renderSearchResultsList({ authorities: authorities.slice(0, 3) });
 
     expect(getByText('LC Demographic Group Terms (LCFGT)')).toBeDefined();
     expect(getByText('STAFF_source')).toBeDefined();
+    expect(getByText('stripes-authority-components.search.sourceFileId.nullOption')).toBeDefined();
   });
 });


### PR DESCRIPTION
## Description
Show 'Not specified' when authority does not have a source file

## Screenshots

![image](https://github.com/folio-org/stripes-authority-components/assets/19309423/9e760e14-7bb1-4f3f-bae8-cdfcfbdf306c)

## Issues
[UISAUTCOMP-93](https://issues.folio.org/browse/UISAUTCOMP-93)