### PR TITLE
UISAUTCOMP-95 Use first page Browse query for facet requests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [UISAUTCOMP-92](https://issues.folio.org/browse/UISAUTCOMP-92) Search box/Browse box- Reset all should shift focus back to search box.
 - [UISAUTCOMP-93](https://issues.folio.org/browse/UISAUTCOMP-93) Add new column called Authority source for browse and search results.
 - [UISAUTCOMP-94](https://issues.folio.org/browse/UISAUTCOMP-94) MARC authority - Keyword search should search natural id.
+- [UISAUTCOMP-95](https://issues.folio.org/browse/UISAUTCOMP-95) Use first page Browse query for facet requests.
 
 ## [3.0.1] (https://github.com/folio-org/stripes-authority-components/tree/v3.0.1) (2023-10-27)
 

--- a/lib/AuthoritiesSearchPane/AuthoritiesSearchPane.js
+++ b/lib/AuthoritiesSearchPane/AuthoritiesSearchPane.js
@@ -19,13 +19,13 @@ import {
 
 const propTypes = {
   excludedFilters: PropTypes.object,
+  firstPageQuery: PropTypes.string.isRequired,
   hasAdvancedSearch: PropTypes.bool,
   height: PropTypes.string,
   isFilterPaneVisible: PropTypes.bool.isRequired,
   isLoading: PropTypes.bool.isRequired,
   onShowDetailView: PropTypes.func,
   onSubmitSearch: PropTypes.func.isRequired,
-  query: PropTypes.string.isRequired,
   resetSelectedRows: PropTypes.func,
   tenantId: PropTypes.string,
   toggleFilterPane: PropTypes.func.isRequired,
@@ -38,7 +38,7 @@ const AuthoritiesSearchPane = ({
   isLoading,
   onSubmitSearch,
   resetSelectedRows,
-  query,
+  firstPageQuery,
   hasAdvancedSearch,
   height,
   tenantId,
@@ -76,7 +76,7 @@ const AuthoritiesSearchPane = ({
         navigationSegmentValue === navigationSegments.browse
           ? (
             <BrowseFilters
-              cqlQuery={query}
+              cqlQuery={firstPageQuery}
               excludedFilters={excludedFilters[navigationSegments.browse]}
               tenantId={tenantId}
             />
@@ -84,7 +84,7 @@ const AuthoritiesSearchPane = ({
           : (
             <SearchFilters
               isSearching={isLoading}
-              cqlQuery={query}
+              cqlQuery={firstPageQuery}
               excludedFilters={excludedFilters[navigationSegments.search]}
               tenantId={tenantId}
             />

--- a/lib/AuthoritiesSearchPane/AuthoritiesSearchPane.js
+++ b/lib/AuthoritiesSearchPane/AuthoritiesSearchPane.js
@@ -19,13 +19,13 @@ import {
 
 const propTypes = {
   excludedFilters: PropTypes.object,
-  firstPageQuery: PropTypes.string.isRequired,
   hasAdvancedSearch: PropTypes.bool,
   height: PropTypes.string,
   isFilterPaneVisible: PropTypes.bool.isRequired,
   isLoading: PropTypes.bool.isRequired,
   onShowDetailView: PropTypes.func,
   onSubmitSearch: PropTypes.func.isRequired,
+  query: PropTypes.string.isRequired,
   resetSelectedRows: PropTypes.func,
   tenantId: PropTypes.string,
   toggleFilterPane: PropTypes.func.isRequired,
@@ -38,7 +38,7 @@ const AuthoritiesSearchPane = ({
   isLoading,
   onSubmitSearch,
   resetSelectedRows,
-  firstPageQuery,
+  query,
   hasAdvancedSearch,
   height,
   tenantId,
@@ -76,7 +76,7 @@ const AuthoritiesSearchPane = ({
         navigationSegmentValue === navigationSegments.browse
           ? (
             <BrowseFilters
-              cqlQuery={firstPageQuery}
+              cqlQuery={query}
               excludedFilters={excludedFilters[navigationSegments.browse]}
               tenantId={tenantId}
             />
@@ -84,7 +84,7 @@ const AuthoritiesSearchPane = ({
           : (
             <SearchFilters
               isSearching={isLoading}
-              cqlQuery={firstPageQuery}
+              cqlQuery={query}
               excludedFilters={excludedFilters[navigationSegments.search]}
               tenantId={tenantId}
             />

--- a/lib/queries/useAuthoritiesBrowse/readme.md
+++ b/lib/queries/useAuthoritiesBrowse/readme.md
@@ -1,0 +1,34 @@
+# useAuthoritiesBrowse
+This hook contains logic of Authority browsing functionality.
+
+### Usage
+
+`useAuthoritiesBrowse` returns an object with following properties:
+
+Name | type | description
+--- | --- | --- |
+`authorities` | array | Array of found Authority records
+`isLoading` | bool | Is a request pending
+`isLoaded` | bool | Has a request finished
+`hasNextPage` | bool | Can browse a next page
+`hasPrevPage` | bool | Can browse a previous page
+`handleLoadMore` | function | Function to fetch more data. Same API as `MCL`'s `onNeedMoreData`
+`query` | string | Formatted query string that is used for fetching results for currently browsed page
+`firstPageQuery` | string | Formatted query string that was used for fetching results for first browsed page (page with anchor)
+`totalRecords` | number | Number of total records found
+
+
+### Props
+Name | type | description | default | required
+--- | --- | --- | --- | ---
+`searchQuery` | string | Seqrch query provided by user | `` | true
+`searchIndex` | string | Search index provided by user | `` | true
+`filters` | object | Selected search filters. Structure: `{ filterName: ['filterValue1', 'filterValue2'] }`| undefined | true
+`pageSize` | number | Number of results per page | undefined | true
+`precedingRecordsCount` | number | Number of records before anchor item in results list | undefined | true
+`browsePageQuery` | string | Query that will be searched when viewing Next or Previous page | undefined | false
+`setBrowsePageQuery` | function | Setter function for `browsePageQuery` | undefined | true
+`browsePage` | number | Numerical order of the current viewed Browse page | undefined | false
+`setBrowsePage` | function | Setter function for `browsePage` | undefined | true
+`navigationSegmentValue` | string | Current segment of MARC authority search and browse view | undefined | false.
+`tenantId` | string | Tenant id in a multi-tenant environment | undefined | false

--- a/lib/queries/useAuthoritiesBrowse/useAuthoritiesBrowse.js
+++ b/lib/queries/useAuthoritiesBrowse/useAuthoritiesBrowse.js
@@ -227,6 +227,7 @@ const useAuthoritiesBrowse = ({
     isLoaded: isFetched,
     handleLoadMore,
     query,
+    firstPageQuery: buildPageQuery(searchQuery, 0),
   });
 };
 

--- a/lib/queries/useAuthoritiesBrowse/useAuthoritiesBrowse.js
+++ b/lib/queries/useAuthoritiesBrowse/useAuthoritiesBrowse.js
@@ -21,19 +21,8 @@ import { useTenantKy } from '../../temp/hooks/useTenantKy';
 
 const AUTHORITIES_BROWSE_API = 'browse/authorities';
 
-const useBrowseRequest = ({
-  filters,
-  searchQuery,
-  searchIndex,
-  startingSearch,
-  pageSize,
-  precedingRecordsCount,
-  tenantId,
-}) => {
-  const ky = useTenantKy({ tenantId });
-  const [namespace] = useNamespace({ key: QUERY_KEY_AUTHORITIES });
-
-  const cqlSearch = startingSearch ? [startingSearch] : [];
+const buildQuery = (searchString, searchIndex, filters) => {
+  const cqlSearch = searchString ? [searchString] : [];
 
   cqlSearch.push(`isTitleHeadingRef==${searchIndex === searchableIndexesValues.NAME_TITLE}`);
 
@@ -48,6 +37,23 @@ const useBrowseRequest = ({
   const headingTypeQuery = buildHeadingTypeQuery(searchIndex);
 
   const query = [...cqlSearch, ...cqlFilters, headingTypeQuery].filter(Boolean).join(' and ');
+
+  return query;
+};
+
+const useBrowseRequest = ({
+  filters,
+  searchQuery,
+  searchIndex,
+  startingSearch,
+  pageSize,
+  precedingRecordsCount,
+  tenantId,
+}) => {
+  const ky = useTenantKy({ tenantId });
+  const [namespace] = useNamespace({ key: QUERY_KEY_AUTHORITIES });
+
+  const query = buildQuery(startingSearch, searchIndex, filters);
 
   const searchParams = {
     query,
@@ -227,7 +233,7 @@ const useAuthoritiesBrowse = ({
     isLoaded: isFetched,
     handleLoadMore,
     query,
-    firstPageQuery: buildPageQuery(searchQuery, 0),
+    firstPageQuery: buildQuery(buildPageQuery(searchQuery, 0), searchIndex, filters),
   });
 };
 


### PR DESCRIPTION
## Description
Fix Facet counts changing when going Next or Prev page in Browse
Use first page query to fetch Browse facets

## Approach
`useAuthoritiesBrowse` returns two query strings: `query` and `firstPageQuery`.
`query` describes search parameters that are used for browsing results for current page.
`firstPageQuery` describes search parameters that were used for browsing results for the initial page (page with anchor).
For facet requests we need to use `firstPageQuery` because if we navigate to next or previous page - the search parameters will change and we will get different facet counts.

For example, user browses `Twain, Mark`. The first page will contain the anchor and some other similar results. If the user then goes to see the previous page - Browse request will contain a parameter `headingRef < "TW, obscure Englishman"`. By using this parameter in facets we will lose the context of the initial browse search and so the facet counts will be different

![image](https://github.com/folio-org/stripes-authority-components/assets/19309423/466cfe95-aa39-43e4-bdcf-9286ce61d731)


## Screenshots

https://github.com/folio-org/stripes-authority-components/assets/19309423/8d802b7e-b8af-4818-b2b5-5466ee24bb40


## Issues
[UISAUTCOMP-95](https://issues.folio.org/browse/UISAUTCOMP-95)

## Related PRs
https://github.com/folio-org/ui-marc-authorities/pull/333
https://github.com/folio-org/ui-plugin-find-authority/pull/88