### PR TITLE
UISAUTCOMP-101 Counter values and options for "Authority source", "Thesaurus" facet options do not change when changing search parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [UISAUTCOMP-94](https://issues.folio.org/browse/UISAUTCOMP-94) MARC authority - Keyword search should search natural id.
 - [UISAUTCOMP-97](https://issues.folio.org/browse/UISAUTCOMP-97) Add Search type dropdown to Advanced search modal.
 - [UISAUTCOMP-98](https://issues.folio.org/browse/UISAUTCOMP-98) *BREAKING* Add authority-source-files interface.
+- [UISAUTCOMP-101](https://issues.folio.org/browse/UISAUTCOMP-101) Counter values and options for "Authority source", "Thesaurus" facet options do not change when changing search parameters
 
 ## [3.0.2] (https://github.com/folio-org/stripes-authority-components/tree/v3.0.2) (2023-11-29)
 

--- a/lib/AuthoritiesSearchPane/AuthoritiesSearchPane.js
+++ b/lib/AuthoritiesSearchPane/AuthoritiesSearchPane.js
@@ -19,6 +19,7 @@ import {
 
 const propTypes = {
   excludedFilters: PropTypes.object,
+  firstPageQuery: PropTypes.string.isRequired,
   hasAdvancedSearch: PropTypes.bool,
   hasMatchSelection: PropTypes.bool,
   hasQueryOption: PropTypes.bool,
@@ -47,6 +48,7 @@ const AuthoritiesSearchPane = ({
   height,
   tenantId,
   onShowDetailView,
+  firstPageQuery,
 }) => {
   const intl = useIntl();
   const { navigationSegmentValue } = useContext(AuthoritiesSearchContext);
@@ -82,7 +84,7 @@ const AuthoritiesSearchPane = ({
         navigationSegmentValue === navigationSegments.browse
           ? (
             <BrowseFilters
-              cqlQuery={query}
+              cqlQuery={firstPageQuery}
               excludedFilters={excludedFilters[navigationSegments.browse]}
               tenantId={tenantId}
             />


### PR DESCRIPTION
## Description
Counter values and options for "Authority source", "Thesaurus" facet options do not change when changing search parameters
Need to send request to facets with current search query parameters

## Screenshots

https://github.com/folio-org/stripes-authority-components/assets/19309423/eca0eaf7-691a-4d5c-96b3-4e67ead8e4bb


## Issues
[UISAUTCOMP-101](https://issues.folio.org/browse/UISAUTCOMP-101)
## Related PRs
https://github.com/folio-org/ui-marc-authorities/pull/345