### PR TITLE
UISAUTCOMP-111 `useUsers` hook - add user ids to cache keys to fetch users when user ids change.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-authoriy-components
 
+## [4.0.1] (IN PROGRESS)
+
+- [UISAUTCOMP-111](https://issues.folio.org/browse/UISAUTCOMP-111) `useUsers` hook - add user ids to cache keys to fetch users when user ids change.
+
 ## [4.0.0] (https://github.com/folio-org/stripes-authority-components/tree/v4.0.0) (2024-03-21)
 
 - [UISAUTCOMP-65](https://issues.folio.org/browse/UISAUTCOMP-65) Remove eslint deps that are already listed in eslint-config-stripes.

--- a/lib/queries/useUsers/useUsers.js
+++ b/lib/queries/useUsers/useUsers.js
@@ -12,7 +12,7 @@ export const useUsers = ids => {
   const userIdSearchParams = ids.map(id => `id=="${id}"`);
 
   const { isFetching, data } = useQuery(
-    [namespace],
+    [namespace, userIdSearchParams],
     async () => {
       return ky.get('users', {
         searchParams: {

--- a/lib/queries/useUsers/useUsers.test.js
+++ b/lib/queries/useUsers/useUsers.test.js
@@ -29,6 +29,7 @@ describe('Given useUsers', () => {
   }));
 
   beforeEach(() => {
+    jest.clearAllMocks();
     useOkapiKy.mockClear().mockReturnValue({
       get: mockGet,
     });
@@ -42,5 +43,25 @@ describe('Given useUsers', () => {
     await act(async () => !result.current.isLoading);
 
     expect(mockGet).toHaveBeenCalledWith('users', { searchParams: { query: 'id=="id-1" or id=="id-2" or id=="id-3"' } });
+  });
+
+  describe('when ids parameter contains new data', () => {
+    it('should make a new request', async () => {
+      const ids = ['id-1'];
+
+      const hook = renderHook((props) => useUsers(props), { wrapper, initialProps: ids });
+
+      await act(async () => !hook.result.current.isLoading);
+
+      expect(mockGet).toHaveBeenCalledWith('users', { searchParams: { query: 'id=="id-1"' } });
+
+      const newIds = ['id-1', 'id-2'];
+
+      hook.rerender(newIds);
+
+      await act(async () => !hook.result.current.isLoading);
+
+      expect(mockGet).toHaveBeenCalledWith('users', { searchParams: { query: 'id=="id-1" or id=="id-2"' } });
+    });
   });
 });


### PR DESCRIPTION
## Description
When a user created a new Source File id for the first time their name is not visible because updaters user data was only loaded upon mount
Added updater ids to `useQuery` cache keys to re-load updaters data when a new updater is added

## Screenshots

https://github.com/folio-org/stripes-authority-components/assets/19309423/3cd4c704-f1ea-42aa-824e-9d16b761d300



## Issues
[UISAUTCOMP-111](https://folio-org.atlassian.net/browse/UISAUTCOMP-111)