### PR TITLE
UISAUTCOMP-117 provide deprecation notice for useUserTenantPermissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [UISAUTCOMP-111](https://issues.folio.org/browse/UISAUTCOMP-111) `useUsers` hook - add user ids to cache keys to fetch users when user ids change.
 - [UISAUTCOMP-112](https://issues.folio.org/browse/UISAUTCOMP-112) Extend auto-open a record functionality.
 - [UISAUTCOMP-113](https://issues.folio.org/browse/UISAUTCOMP-113) Re-position advanced search button when there is too little space in the search pane.
+- [UISAUTCOMP-117](https://issues.folio.org/browse/UISAUTCOMP-117) Provide deprecation notice to `useUserTenantPermissions.js`.
 
 ## [4.0.0] (https://github.com/folio-org/stripes-authority-components/tree/v4.0.0) (2024-03-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Change history for stripes-authoriy-components
 
+## [4.1.0] (IN PROGRESS)
+
+- [UISAUTCOMP-117](https://issues.folio.org/browse/UISAUTCOMP-117) Provide deprecation notice to `useUserTenantPermissions.js`.
+
 ## [4.0.1] (https://github.com/folio-org/stripes-authority-components/tree/v4.0.1) (2024-04-02)
 
 - [UISAUTCOMP-111](https://issues.folio.org/browse/UISAUTCOMP-111) `useUsers` hook - add user ids to cache keys to fetch users when user ids change.
 - [UISAUTCOMP-112](https://issues.folio.org/browse/UISAUTCOMP-112) Extend auto-open a record functionality.
 - [UISAUTCOMP-113](https://issues.folio.org/browse/UISAUTCOMP-113) Re-position advanced search button when there is too little space in the search pane.
-- [UISAUTCOMP-117](https://issues.folio.org/browse/UISAUTCOMP-117) Provide deprecation notice to `useUserTenantPermissions.js`.
 
 ## [4.0.0] (https://github.com/folio-org/stripes-authority-components/tree/v4.0.0) (2024-03-21)
 

--- a/lib/queries/useUserTenantPermissions/useUserTenantPermissions.js
+++ b/lib/queries/useUserTenantPermissions/useUserTenantPermissions.js
@@ -13,6 +13,9 @@ const useUserTenantPermissions = (
   { userId, tenantId },
   options = {},
 ) => {
+  // eslint-disable-next-line no-console
+  console.warn('This hook is deprecated. It will be removed in v5.0.0. Import it from @folio/stripes/core instead.');
+
   const ky = useOkapiKy();
   const api = ky.extend({
     hooks: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-authority-components",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "Component library for Stripes Authority modules",
   "repository": "https://github.com/folio-org/stripes-authority-components",
   "main": "index.js",


### PR DESCRIPTION
Permission-related functionality is being centralized in `@folio/stripes-core`, consolidating reliance on the `permissions` interface within that single module.

Should be merged after https://github.com/folio-org/stripes-core/pull/1453

Refs [UISAUTCOMP-117](https://folio-org.atlassian.net/browse/UISAUTCOMP-117), [STCOR-830](https://folio-org.atlassian.net/browse/UISAUTCOMP-117)
