### PR TITLE
UISAUTCOMP-119: Pass `source` with `failure` and `failureMessage` to the `SearchAndSortNoResultsMessage` component to display the correct message in the results if there is no permission to search records.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [4.1.0] (IN PROGRESS)
 
 - [UISAUTCOMP-117](https://issues.folio.org/browse/UISAUTCOMP-117) Provide deprecation notice to `useUserTenantPermissions.js`.
-- [UISAUTCOMP-117](https://issues.folio.org/browse/UISAUTCOMP-119) Pass `source` with `failure` and `failureMessage` to the `SearchAndSortNoResultsMessage` component to display the correct message in the results if there is no permission to search records.
+- [UISAUTCOMP-119](https://issues.folio.org/browse/UISAUTCOMP-119) Pass `source` with `failure` and `failureMessage` to the `SearchAndSortNoResultsMessage` component to display the correct message in the results if there is no permission to search records.
 
 ## [4.0.1] (https://github.com/folio-org/stripes-authority-components/tree/v4.0.1) (2024-04-02)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [4.1.0] (IN PROGRESS)
 
 - [UISAUTCOMP-117](https://issues.folio.org/browse/UISAUTCOMP-117) Provide deprecation notice to `useUserTenantPermissions.js`.
+- [UISAUTCOMP-117](https://issues.folio.org/browse/UISAUTCOMP-119) Pass `source` with `failure` and `failureMessage` to the `SearchAndSortNoResultsMessage` component to display the correct message in the results if there is no permission to search records.
 
 ## [4.0.1] (https://github.com/folio-org/stripes-authority-components/tree/v4.0.1) (2024-04-02)
 

--- a/lib/SearchResultsList/SearchResultsList.js
+++ b/lib/SearchResultsList/SearchResultsList.js
@@ -4,7 +4,6 @@ import {
 } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
-import noop from 'lodash/noop';
 
 import {
   MultiColumnList,
@@ -27,6 +26,7 @@ const propTypes = {
   authorities: PropTypes.arrayOf(AuthorityShape).isRequired,
   columnMapping: PropTypes.object,
   columnWidths: PropTypes.object,
+  error: PropTypes.object,
   formatter: PropTypes.object,
   hasFilters: PropTypes.bool.isRequired,
   hasNextPage: PropTypes.bool,
@@ -57,6 +57,7 @@ const SearchResultsList = ({
   authorities,
   columnWidths,
   columnMapping,
+  error,
   formatter,
   totalResults,
   loading,
@@ -147,9 +148,18 @@ const SearchResultsList = ({
     () => ({
       loaded: () => (hasFilters || query) && loaded,
       pending: () => loading,
-      failure: noop,
+      failure: () => error,
+      failureMessage() {
+        const status = error.response.status;
+
+        if (status === 403) {
+          return intl.formatMessage({ id: 'stripes-authority-components.authorities.error.forbidden' });
+        }
+
+        return null;
+      },
     }),
-    [loading, hasFilters, query, loaded],
+    [loading, hasFilters, query, loaded, error, intl],
   );
 
   return (
@@ -204,6 +214,7 @@ SearchResultsList.propTypes = propTypes;
 
 SearchResultsList.defaultProps = {
   columnMapping: {},
+  error: null,
   formatter: {},
   columnWidths: {
     [searchResultListColumns.SELECT]: { min: 30, max: 30 },

--- a/lib/SearchResultsList/SearchResultsList.test.js
+++ b/lib/SearchResultsList/SearchResultsList.test.js
@@ -285,4 +285,18 @@ describe('Given SearchResultsList', () => {
       expect(queryByText('stripes-authority-components.search.sourceFileId.nullOption')).toBeNull();
     });
   });
+
+  describe('when there is no permission to search for records', () => {
+    it('should display the error message', () => {
+      const { getByText } = renderSearchResultsList({
+        authorities: [],
+        totalResults: 0,
+        query: 'test=abc',
+        loaded: true,
+        error: { response: { status: 403 } },
+      });
+
+      expect(getByText('stripes-authority-components.authorities.error.forbidden')).toBeDefined();
+    });
+  });
 });

--- a/lib/queries/useAuthorities/useAuthorities.js
+++ b/lib/queries/useAuthorities/useAuthorities.js
@@ -143,6 +143,7 @@ const useAuthorities = ({
     isFetching,
     isFetched,
     data,
+    error,
   } = useQuery(
     [namespace, searchParams],
     () => {
@@ -176,6 +177,7 @@ const useAuthorities = ({
     isLoading: isFetching,
     isLoaded: isFetched,
     query: cqlQuery,
+    error,
   });
 };
 

--- a/lib/queries/useAuthoritiesBrowse/useAuthoritiesBrowse.js
+++ b/lib/queries/useAuthoritiesBrowse/useAuthoritiesBrowse.js
@@ -67,6 +67,7 @@ const useBrowseRequest = ({
     isFetching,
     isFetched,
     data,
+    error,
   } = useQuery(
     [namespace, 'authorities', searchParams],
     () => {
@@ -88,6 +89,7 @@ const useBrowseRequest = ({
     isFetching,
     data,
     query,
+    error,
   });
 };
 
@@ -182,6 +184,7 @@ const useAuthoritiesBrowse = ({
     isFetched,
     isFetching,
     query,
+    error,
   } = useBrowseRequest({
     filters,
     searchQuery: currentQuery,
@@ -236,6 +239,7 @@ const useAuthoritiesBrowse = ({
     handleLoadMore,
     query,
     firstPageQuery: buildQuery(buildPageQuery(searchQuery, 0), searchIndex, filters),
+    error,
   });
 };
 

--- a/translations/stripes-authority-components/en.json
+++ b/translations/stripes-authority-components/en.json
@@ -47,5 +47,6 @@
   "search-results-list.unselectAll": "Select all records on this page",
 
   "authority.view.error.notFound": "Authority record not found",
-  "authority.view.error.unknown": "An unknown error occurred"
+  "authority.view.error.unknown": "An unknown error occurred",
+  "authorities.error.forbidden": "User does not have permission to search authority records."
 }


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIEH-57 Create example component

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose

Display the correct message in the results if there is no permission to search records.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color
  palette does not provide enough contrast for certain classes of
  visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIEH-57
 -->

## Related PRs
https://github.com/folio-org/ui-marc-authorities/pull/399
https://github.com/folio-org/ui-plugin-find-authority/pull/99

## Issues
[UISAUTCOMP-119](https://folio-org.atlassian.net/browse/UISAUTCOMP-119)

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 Bad:
  Made a dark color of #333, a medium color of #ccc

 Good:
   This introduces three abstract contrast levels that developers can
   use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Screenshots




https://github.com/folio-org/stripes-authority-components/assets/77053927/d7265fa3-3d43-4f4b-8caa-0a8351973e9f




<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
