### PR TITLE
UISAUTCOMP-124: SearchResultsList - pass `sortDirection` and `showSortIndicator` props.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [UISAUTCOMP-117](https://issues.folio.org/browse/UISAUTCOMP-117) Provide deprecation notice to `useUserTenantPermissions.js`.
 - [UISAUTCOMP-119](https://issues.folio.org/browse/UISAUTCOMP-119) Pass `source` with `failure` and `failureMessage` to the `SearchAndSortNoResultsMessage` component to display the correct message in the results if there is no permission to search records.
 - [UISAUTCOMP-123](https://issues.folio.org/browse/UISAUTCOMP-123) Pass the `isCursorAtEnd` prop to the `TextArea` component.
+- [UISAUTCOMP-124](https://issues.folio.org/browse/UISAUTCOMP-124) `SearchResultsList` - pass `sortDirection` and `showSortIndicator` props.
 
 ## [4.0.1] (https://github.com/folio-org/stripes-authority-components/tree/v4.0.1) (2024-04-02)
 

--- a/lib/SearchResultsList/SearchResultsList.js
+++ b/lib/SearchResultsList/SearchResultsList.js
@@ -46,6 +46,7 @@ const propTypes = {
   pageSize: PropTypes.number.isRequired,
   query: PropTypes.string.isRequired,
   renderHeadingRef: PropTypes.func.isRequired,
+  showSortIndicator: PropTypes.bool,
   sortedColumn: PropTypes.string,
   sortOrder: PropTypes.string,
   toggleFilterPane: PropTypes.func.isRequired,
@@ -65,6 +66,7 @@ const SearchResultsList = ({
   pageSize,
   onNeedMoreData,
   visibleColumns,
+  showSortIndicator,
   sortedColumn,
   sortOrder,
   onHeaderClick,
@@ -183,7 +185,9 @@ const SearchResultsList = ({
       pageAmount={pageSize}
       loading={loading}
       sortedColumn={sortedColumn}
+      sortDirection={sortOrder}
       sortOrder={sortOrder}
+      showSortIndicator={showSortIndicator}
       onHeaderClick={onHeaderClick}
       autosize
       hidePageIndices={hidePageIndices}
@@ -228,6 +232,7 @@ SearchResultsList.defaultProps = {
   itemToView: null,
   onRowFocus: null,
   onHeaderClick: null,
+  showSortIndicator: false,
   sortedColumn: null,
   sortOrder: null,
   totalResults: NaN,

--- a/lib/SearchResultsList/SearchResultsList.test.js
+++ b/lib/SearchResultsList/SearchResultsList.test.js
@@ -127,18 +127,6 @@ describe('Given SearchResultsList', () => {
     expect(mockRenderHeadingRef).toHaveBeenNthCalledWith(2, expect.objectContaining(authorities[1]), undefined);
   });
 
-  describe('when search is pending', () => {
-    it('should display pending message', () => {
-      const { getByText } = renderSearchResultsList({
-        authorities: [],
-        totalResults: 0,
-        loading: true,
-      });
-
-      expect(getByText('stripes-smart-components.sas.noResults.loading')).toBeDefined();
-    });
-  });
-
   describe('when search is finished and no results were returned', () => {
     it('should display pending message', () => {
       const { getByText } = renderSearchResultsList({


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIEH-57 Create example component

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
SearchResultsList:
 1. Show an arrow icon when a user sorts a list;
 2. show a double arrow icon when a column is sortable and currently not sorted.
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color
  palette does not provide enough contrast for certain classes of
  visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIEH-57
 -->

## Approach
1. Pass `sortDirection` to MCL.
2. Pass `showSortIndicator` to MCL.

Removed failed test. It failed before this PR. MCL already shows column headers in results during loading.
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 Bad:
  Made a dark color of #333, a medium color of #ccc

 Good:
   This introduces three abstract contrast levels that developers can
   use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Related PRs
https://github.com/folio-org/stripes-components/pull/2333

## Issues
[UISAUTCOMP-124](https://folio-org.atlassian.net/browse/UISAUTCOMP-124)

## Screenshots


https://github.com/user-attachments/assets/12212e48-e4e9-4ab8-937a-50105c518336
<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
