### PR TITLE
UISAUTCOMP-126 Handle cases when `authRefType` is not defined in records.

### DIFF
--- a/.github/workflows/build-npm-release.yml
+++ b/.github/workflows/build-npm-release.yml
@@ -148,7 +148,7 @@ jobs:
           comment_title: Jest Unit Test Statistics
 
       - name: Publish Jest coverage report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: jest-coverage-report
@@ -156,7 +156,7 @@ jobs:
           retention-days: 30
 
       - name: Publish yarn.lock
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: yarn.lock

--- a/.github/workflows/build-npm.yml
+++ b/.github/workflows/build-npm.yml
@@ -102,7 +102,7 @@ jobs:
           comment_title: Jest Unit Test Statistics
 
       - name: Publish Jest coverage report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: always()
         with:
           name: jest-coverage-report
@@ -110,7 +110,7 @@ jobs:
           retention-days: 30
 
       - name: Publish yarn.lock
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: yarn.lock

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [UISAUTCOMP-119](https://issues.folio.org/browse/UISAUTCOMP-119) Pass `source` with `failure` and `failureMessage` to the `SearchAndSortNoResultsMessage` component to display the correct message in the results if there is no permission to search records.
 - [UISAUTCOMP-123](https://issues.folio.org/browse/UISAUTCOMP-123) Pass the `isCursorAtEnd` prop to the `TextArea` component.
 - [UISAUTCOMP-124](https://issues.folio.org/browse/UISAUTCOMP-124) `SearchResultsList` - pass `sortDirection` and `showSortIndicator` props.
+- [UISAUTCOMP-126](https://issues.folio.org/browse/UISAUTCOMP-126) Handle cases when `authRefType` is not defined in records.
 
 ## [4.0.1] (https://github.com/folio-org/stripes-authority-components/tree/v4.0.1) (2024-04-02)
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -70,7 +70,7 @@ export const markHighlightedFields = (marcSource, authority, authorityMappingRul
   const marcFields = marcSource.data.parsedRecord?.content.fields.map(field => {
     const tag = Object.keys(field)[0];
 
-    const isHighlightedTag = highlightAuthRefFields[authority.data.authRefType].test(tag);
+    const isHighlightedTag = highlightAuthRefFields[authority.data.authRefType]?.test(tag);
 
     if (!isHighlightedTag) {
       return field;


### PR DESCRIPTION
## Description
Unmapped 1xx fields will cause Authority records to have undefined `authRefType`
This PR will handle this case when `authRefType` is undefined

## Screenshots

https://github.com/user-attachments/assets/d99143ab-0e9a-42e3-8fff-400f86c1c77d


## Issues
[UISAUTCOMP-126](https://folio-org.atlassian.net/browse/UISAUTCOMP-126)