### PR TITLE
UISAUTCOMP-127 Change MARC authority search to "all" for full-text fields.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [UISAUTCOMP-123](https://issues.folio.org/browse/UISAUTCOMP-123) Pass the `isCursorAtEnd` prop to the `TextArea` component.
 - [UISAUTCOMP-124](https://issues.folio.org/browse/UISAUTCOMP-124) `SearchResultsList` - pass `sortDirection` and `showSortIndicator` props.
 - [UISAUTCOMP-126](https://issues.folio.org/browse/UISAUTCOMP-126) Handle cases when `authRefType` is not defined in records.
+- [UISAUTCOMP-127](https://issues.folio.org/browse/UISAUTCOMP-127) Change MARC authority search to "all" for full-text fields.
 
 ## [4.0.1] (https://github.com/folio-org/stripes-authority-components/tree/v4.0.1) (2024-04-02)
 

--- a/lib/queries/useAuthorities/useAuthorities.test.js
+++ b/lib/queries/useAuthorities/useAuthorities.test.js
@@ -94,7 +94,7 @@ describe('Given useAuthorities', () => {
 
         await act(async () => !result.current.isLoading);
 
-        expect(result.current.query).toEqual('(keyword=="test" or naturalId="test") sortBy authRefType/sort.descending');
+        expect(result.current.query).toEqual('(keyword all "test" or naturalId="test") sortBy authRefType/sort.descending');
       });
     });
 
@@ -113,7 +113,7 @@ describe('Given useAuthorities', () => {
 
         await act(async () => !result.current.isLoading);
 
-        expect(result.current.query).toEqual('(keyword=="test" or naturalId="test") sortBy authRefType/sort.ascending');
+        expect(result.current.query).toEqual('(keyword all "test" or naturalId="test") sortBy authRefType/sort.ascending');
       });
     });
   });
@@ -178,7 +178,7 @@ describe('Given useAuthorities', () => {
     });
 
     expect(result_.current.query).toBe(
-      '(keyword=="Apple & \\"Honey\\" products" or naturalId="Apple & \\"Honey\\" products")',
+      '(keyword all "Apple & \\"Honey\\" products" or naturalId="Apple & \\"Honey\\" products")',
     );
   });
 
@@ -203,7 +203,7 @@ describe('Given useAuthorities', () => {
         result_ = result;
       });
 
-      expect(result_.current.query).toBe('(topicalTerm=="test" or sftTopicalTerm=="test" or saftTopicalTerm=="test")');
+      expect(result_.current.query).toBe('(topicalTerm all "test" or sftTopicalTerm all "test" or saftTopicalTerm all "test")');
     });
   });
 
@@ -231,7 +231,7 @@ describe('Given useAuthorities', () => {
           result_ = result;
         });
 
-        expect(result_.current.query).toBe('(topicalTerm=="test") and (authRefType==("Authorized"))');
+        expect(result_.current.query).toBe('(topicalTerm all "test") and (authRefType==("Authorized"))');
       });
     });
   });

--- a/lib/queries/utils/buildQuery.js
+++ b/lib/queries/utils/buildQuery.js
@@ -49,7 +49,7 @@ export const formatHeadingsQuery = (indexData, queryTemplate, filters, seeAlsoJo
 
 const buildQuery = ({
   searchIndex,
-  comparator = '==',
+  comparator = 'all',
   seeAlsoJoin = 'or',
   filters = {},
   query,
@@ -61,13 +61,13 @@ const buildQuery = ({
   }
 
   if (searchIndex === searchableIndexesValues.KEYWORD) {
-    return `(${searchableIndexesValues.KEYWORD}=="%{query}" or naturalId="%{query}")`;
+    return `(${searchableIndexesValues.KEYWORD} all "%{query}" or naturalId="%{query}")`;
   }
 
   if (searchIndex === searchableIndexesValues.CHILDREN_SUBJECT_HEADING) {
     const childrenSubjectHeadingData = indexData[0];
 
-    return `((${searchableIndexesValues.KEYWORD}=="%{query}" or naturalId="%{query}") and ${childrenSubjectHeadingData.name}=="b")`;
+    return `((${searchableIndexesValues.KEYWORD} all "%{query}" or naturalId="%{query}") and ${childrenSubjectHeadingData.name}=="b")`;
   }
 
   if (searchIndex === searchableIndexesValues.IDENTIFIER) {
@@ -84,7 +84,7 @@ const buildQuery = ({
     return `${lccn}="${query.trim()}"`;
   }
 
-  const queryTemplate = name => `${name}${comparator}"%{query}"`;
+  const queryTemplate = name => `${name} ${comparator} "%{query}"`;
 
   const headingsQuery = formatHeadingsQuery(indexData, queryTemplate, filters, seeAlsoJoin);
 

--- a/lib/queries/utils/buildQuery.test.js
+++ b/lib/queries/utils/buildQuery.test.js
@@ -13,7 +13,7 @@ describe('Given buildQuery', () => {
         query: 'somevalue',
       });
 
-      expect(query).toBe('(personalName=="%{query}" or sftPersonalName=="%{query}" or saftPersonalName=="%{query}")');
+      expect(query).toBe('(personalName all "%{query}" or sftPersonalName all "%{query}" or saftPersonalName all "%{query}")');
     });
   });
 
@@ -35,7 +35,7 @@ describe('Given buildQuery', () => {
         query: 'somevalue',
       });
 
-      expect(query).toBe('(geographicName=="%{query}" or sftGeographicName=="%{query}" or saftGeographicName=="%{query}")');
+      expect(query).toBe('(geographicName all "%{query}" or sftGeographicName all "%{query}" or saftGeographicName all "%{query}")');
     });
   });
 
@@ -46,7 +46,7 @@ describe('Given buildQuery', () => {
         query: 'somevalue',
       });
 
-      expect(query).toBe('(keyword=="%{query}" or naturalId="%{query}")');
+      expect(query).toBe('(keyword all "%{query}" or naturalId="%{query}")');
     });
   });
 
@@ -113,7 +113,7 @@ describe('Given buildQuery', () => {
         query: 'somevalue',
       });
 
-      expect(query).toBe('((keyword=="%{query}" or naturalId="%{query}") and subjectHeadings=="b")');
+      expect(query).toBe('((keyword all "%{query}" or naturalId="%{query}") and subjectHeadings=="b")');
     });
   });
 
@@ -127,7 +127,7 @@ describe('Given buildQuery', () => {
         query: 'somevalue',
       });
 
-      expect(query).toEqual('(personalName=="%{query}" or saftPersonalName=="%{query}")');
+      expect(query).toEqual('(personalName all "%{query}" or saftPersonalName all "%{query}")');
     });
 
     it('should return correct query when \'excludeSeeFromAlso\' is selected', () => {
@@ -139,7 +139,7 @@ describe('Given buildQuery', () => {
         query: 'somevalue',
       });
 
-      expect(query).toEqual('(personalName=="%{query}" or sftPersonalName=="%{query}")');
+      expect(query).toEqual('(personalName all "%{query}" or sftPersonalName all "%{query}")');
     });
 
     it('should return correct query when both \'excludeSeeFromAlso\' and \'excludeSeeFromAlso\' are selected', () => {
@@ -154,7 +154,7 @@ describe('Given buildQuery', () => {
         query: 'somevalue',
       });
 
-      expect(query).toEqual('(personalName=="%{query}")');
+      expect(query).toEqual('(personalName all "%{query}")');
     });
   });
 });


### PR DESCRIPTION
## Description
Change MARC authority search to "all" for full-text fields.

## Issues
[UISAUTCOMP-127](https://folio-org.atlassian.net/browse/UISAUTCOMP-127)