### PR TITLE
UISAUTCOMP-133 Handle uncaught error when a search request fails.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-authoriy-components
 
+## [5.0.2] (IN PROGRESS)
+
+- [UISAUTCOMP-133](https://issues.folio.org/browse/UISAUTCOMP-133) Handle uncaught error when a search request fails.
+
 ## [5.0.1] (https://github.com/folio-org/stripes-authority-components/tree/v5.0.1) (2024-11-14)
 
 - [UISAUTCOMP-130](https://issues.folio.org/browse/UISAUTCOMP-130) Provide a prop to `<AcqDateRangeFilter>` to subscribe to search form resets.

--- a/lib/SearchResultsList/SearchResultsList.js
+++ b/lib/SearchResultsList/SearchResultsList.js
@@ -154,13 +154,13 @@ const SearchResultsList = ({
       pending: () => loading,
       failure: () => error,
       failureMessage() {
-        const status = error.response.status;
+        const status = error?.response?.status;
 
         if (status === 403) {
           return intl.formatMessage({ id: 'stripes-authority-components.authorities.error.forbidden' });
         }
 
-        return null;
+        return intl.formatMessage({ id: 'stripes-authority-components.search-results-list.error.badRequest' }, { query });
       },
     }),
     [loading, hasFilters, query, loaded, error, intl],

--- a/lib/SearchResultsList/SearchResultsList.test.js
+++ b/lib/SearchResultsList/SearchResultsList.test.js
@@ -287,4 +287,18 @@ describe('Given SearchResultsList', () => {
       expect(getByText('stripes-authority-components.authorities.error.forbidden')).toBeDefined();
     });
   });
+
+  describe('when a search fails due to an unknown http error', () => {
+    it('should display a generic error message', () => {
+      const { getByText } = renderSearchResultsList({
+        authorities: [],
+        totalResults: 0,
+        query: 'test=abc',
+        loaded: true,
+        error: { response: { status: 400 } },
+      });
+
+      expect(getByText('stripes-authority-components.search-results-list.error.badRequest')).toBeDefined();
+    });
+  });
 });

--- a/translations/stripes-authority-components/en.json
+++ b/translations/stripes-authority-components/en.json
@@ -45,6 +45,7 @@
   "search-results-list.paneSub": "{totalRecords, number} {totalRecords, plural, one {record found} other {records found}}",
   "search-results-list.selectAll": "Unselect all records on this page",
   "search-results-list.unselectAll": "Select all records on this page",
+  "search-results-list.error.badRequest": "Search could not be processed for {query}. Please check your query and try again.",
 
   "authority.view.error.notFound": "Authority record not found",
   "authority.view.error.unknown": "An unknown error occurred",


### PR DESCRIPTION
## Description
Handle uncaught error when a search request fails.

## Screenshots

https://github.com/user-attachments/assets/83373222-f6ec-447f-8cec-4c409f037263



## Issues
[UISAUTCOMP-133](https://folio-org.atlassian.net/browse/UISAUTCOMP-133)