### PR TITLE
UISAUTCOMP-140 Change query building process for Browse filters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [UISAUTCOMP-136](https://folio-org.atlassian.net/browse/UISAUTCOMP-136) Spitfire - migrate to shared CI workflows.
 - [UISAUTCOMP-118](https://folio-org.atlassian.net/browse/UISAUTCOMP-118) React v19: refactor away from default props for functional components.
+- [UISAUTCOMP-140](https://folio-org.atlassian.net/browse/UISAUTCOMP-140) Change query building process for Browse filters.
 
 ## [5.0.3] (https://github.com/folio-org/stripes-authority-components/tree/v5.0.3) (2024-12-27)
 

--- a/lib/AuthoritiesSearchPane/AuthoritiesSearchPane.js
+++ b/lib/AuthoritiesSearchPane/AuthoritiesSearchPane.js
@@ -19,7 +19,6 @@ import {
 
 const propTypes = {
   excludedFilters: PropTypes.object,
-  firstPageQuery: PropTypes.string.isRequired,
   hasAdvancedSearch: PropTypes.bool,
   hasMatchSelection: PropTypes.bool,
   hasQueryOption: PropTypes.bool,
@@ -40,7 +39,6 @@ const AuthoritiesSearchPane = ({
   isLoading,
   onSubmitSearch,
   query,
-  firstPageQuery,
   excludedFilters = {},
   resetSelectedRows = noop,
   hasAdvancedSearch = false,
@@ -84,7 +82,6 @@ const AuthoritiesSearchPane = ({
         navigationSegmentValue === navigationSegments.browse
           ? (
             <BrowseFilters
-              cqlQuery={firstPageQuery}
               excludedFilters={excludedFilters[navigationSegments.browse]}
               tenantId={tenantId}
             />

--- a/lib/AuthoritiesSearchPane/AuthoritiesSearchPane.js
+++ b/lib/AuthoritiesSearchPane/AuthoritiesSearchPane.js
@@ -84,6 +84,7 @@ const AuthoritiesSearchPane = ({
         navigationSegmentValue === navigationSegments.browse
           ? (
             <BrowseFilters
+              query={query}
               cqlQuery={firstPageQuery}
               excludedFilters={excludedFilters[navigationSegments.browse]}
               tenantId={tenantId}

--- a/lib/AuthoritiesSearchPane/AuthoritiesSearchPane.js
+++ b/lib/AuthoritiesSearchPane/AuthoritiesSearchPane.js
@@ -84,7 +84,6 @@ const AuthoritiesSearchPane = ({
         navigationSegmentValue === navigationSegments.browse
           ? (
             <BrowseFilters
-              query={query}
               cqlQuery={firstPageQuery}
               excludedFilters={excludedFilters[navigationSegments.browse]}
               tenantId={tenantId}

--- a/lib/BrowseFilters/BrowseFilters.js
+++ b/lib/BrowseFilters/BrowseFilters.js
@@ -45,6 +45,11 @@ const BrowseFilters = ({
 
   const ALL_QUERY = '*';
 
+  // for search we would take whatever value user has entered in the search box and build facets query with that
+  // but for browse we can use '*' as an entered value since we're browsing across all the records
+  // and instead of using `headingRef>=query or headingRef<query` we can use `personalName all "*" or or sftPersonalName all "*"...`
+  // this allows us to get correct facets values that depend on which heading type we're browsing
+
   const buildRegularSearch = useCallback(() => {
     const compileQuery = template(
       buildQuery({
@@ -62,7 +67,7 @@ const BrowseFilters = ({
     cqlSearch.push(compiledQuery);
 
     return cqlSearch;
-  }, [filters]);
+  }, [filters, searchIndex]);
 
   const cqlSearch = buildRegularSearch();
 

--- a/lib/BrowseFilters/BrowseFilters.js
+++ b/lib/BrowseFilters/BrowseFilters.js
@@ -52,21 +52,21 @@ const BrowseFilters = ({
     navigationSegmentValue,
   } = useContext(AuthoritiesSearchContext);
 
-  const searchQuery = '*';
+  const ALL_QUERY = '*';
 
   const buildRegularSearch = () => {
     const compileQuery = template(
       buildQuery({
         searchIndex,
         filters,
-        query: searchQuery,
+        query: ALL_QUERY,
       }),
       { interpolate: /%{([\s\S]+?)}/g },
     );
 
     const cqlSearch = [];
 
-    const queryParam = getProcessedQuery(searchQuery, searchIndex);
+    const queryParam = getProcessedQuery(ALL_QUERY, searchIndex);
     const compiledQuery = compileQuery({ query: queryParam });
 
     cqlSearch.push(compiledQuery);
@@ -74,7 +74,7 @@ const BrowseFilters = ({
     return cqlSearch;
   };
 
-  const cqlSearch = buildRegularSearch(searchIndex, searchQuery, filters);
+  const cqlSearch = buildRegularSearch(searchIndex, ALL_QUERY, filters);
 
   const cqlFilters = Object.entries(filters)
     .filter(([, filterValues]) => filterValues.length)

--- a/lib/BrowseFilters/BrowseFilters.js
+++ b/lib/BrowseFilters/BrowseFilters.js
@@ -4,6 +4,9 @@ import {
 } from 'react';
 import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
+import template from 'lodash/template';
+
+import { escapeCqlValue } from '@folio/stripes/util';
 
 import { AuthoritiesSearchContext } from '../';
 import { ReferencesFilter } from '../ReferencesFilter';
@@ -12,30 +15,76 @@ import { AuthoritySourceFilter } from '../AuthoritySourceFilter';
 import { SharedFilter } from '../SharedFilter';
 import { useSectionToggle } from '../hooks';
 import { useFacets } from '../queries';
-import { FILTERS } from '../constants';
+import {
+  searchableIndexesValues,
+  FILTERS,
+  filterConfig,
+} from '../constants';
 import {
   getSelectedFacets,
   onClearFilter,
   updateFilters,
 } from '../utils';
+import { buildQuery } from '../queries/utils';
 
 const propTypes = {
-  cqlQuery: PropTypes.string,
   excludedFilters: PropTypes.arrayOf(PropTypes.string),
   tenantId: PropTypes.string,
 };
 
+const getProcessedQuery = (query, searchIndex) => {
+  const queryParam = searchIndex === searchableIndexesValues.IDENTIFIER
+    ? query
+    : query.trim();
+
+  return escapeCqlValue(queryParam);
+};
+
 const BrowseFilters = ({
-  cqlQuery = '',
   excludedFilters = [],
   tenantId = null,
 }) => {
   const intl = useIntl();
   const {
+    searchIndex,
     filters,
     setFilters,
     navigationSegmentValue,
   } = useContext(AuthoritiesSearchContext);
+
+  const searchQuery = '*';
+
+  const buildRegularSearch = () => {
+    const compileQuery = template(
+      buildQuery({
+        searchIndex,
+        filters,
+        query: searchQuery,
+      }),
+      { interpolate: /%{([\s\S]+?)}/g },
+    );
+
+    const cqlSearch = [];
+
+    const queryParam = getProcessedQuery(searchQuery, searchIndex);
+    const compiledQuery = compileQuery({ query: queryParam });
+
+    cqlSearch.push(compiledQuery);
+
+    return cqlSearch;
+  };
+
+  const cqlSearch = buildRegularSearch(searchIndex, searchQuery, filters);
+
+  const cqlFilters = Object.entries(filters)
+    .filter(([, filterValues]) => filterValues.length)
+    .map(([filterName, filterValues]) => {
+      const filterData = filterConfig.find(filter => filter.name === filterName);
+
+      return filterData.parse(filterValues);
+    });
+
+  const cqlQuery = [...cqlSearch, ...cqlFilters].join(' and ');
 
   const [filterAccordions, { handleSectionToggle }] = useSectionToggle({
     [FILTERS.SHARED]: false,

--- a/lib/BrowseFilters/BrowseFilters.js
+++ b/lib/BrowseFilters/BrowseFilters.js
@@ -16,7 +16,6 @@ import { SharedFilter } from '../SharedFilter';
 import { useSectionToggle } from '../hooks';
 import { useFacets } from '../queries';
 import {
-  searchableIndexesValues,
   FILTERS,
   filterConfig,
 } from '../constants';
@@ -30,14 +29,6 @@ import { buildQuery } from '../queries/utils';
 const propTypes = {
   excludedFilters: PropTypes.arrayOf(PropTypes.string),
   tenantId: PropTypes.string,
-};
-
-const getProcessedQuery = (query, searchIndex) => {
-  const queryParam = searchIndex === searchableIndexesValues.IDENTIFIER
-    ? query
-    : query.trim();
-
-  return escapeCqlValue(queryParam);
 };
 
 const BrowseFilters = ({
@@ -66,13 +57,12 @@ const BrowseFilters = ({
 
     const cqlSearch = [];
 
-    const queryParam = getProcessedQuery(ALL_QUERY, searchIndex);
-    const compiledQuery = compileQuery({ query: queryParam });
+    const compiledQuery = compileQuery({ query: ALL_QUERY });
 
     cqlSearch.push(compiledQuery);
 
     return cqlSearch;
-  }, [filters, searchIndex]);
+  }, [filters]);
 
   const cqlSearch = buildRegularSearch();
 

--- a/lib/BrowseFilters/BrowseFilters.js
+++ b/lib/BrowseFilters/BrowseFilters.js
@@ -54,7 +54,7 @@ const BrowseFilters = ({
 
   const ALL_QUERY = '*';
 
-  const buildRegularSearch = () => {
+  const buildRegularSearch = useCallback(() => {
     const compileQuery = template(
       buildQuery({
         searchIndex,
@@ -72,9 +72,9 @@ const BrowseFilters = ({
     cqlSearch.push(compiledQuery);
 
     return cqlSearch;
-  };
+  }, [filters, searchIndex]);
 
-  const cqlSearch = buildRegularSearch(searchIndex, ALL_QUERY, filters);
+  const cqlSearch = buildRegularSearch();
 
   const cqlFilters = Object.entries(filters)
     .filter(([, filterValues]) => filterValues.length)

--- a/lib/BrowseFilters/BrowseFilters.js
+++ b/lib/BrowseFilters/BrowseFilters.js
@@ -6,8 +6,6 @@ import PropTypes from 'prop-types';
 import { useIntl } from 'react-intl';
 import template from 'lodash/template';
 
-import { escapeCqlValue } from '@folio/stripes/util';
-
 import { AuthoritiesSearchContext } from '../';
 import { ReferencesFilter } from '../ReferencesFilter';
 import { MultiSelectionFacet } from '../MultiSelectionFacet';

--- a/lib/BrowseFilters/BrowseFilters.test.js
+++ b/lib/BrowseFilters/BrowseFilters.test.js
@@ -54,7 +54,6 @@ const renderBrowseFilters = (props = {}, ctxValue = defaultCtxValue) => render(
   <Harness authoritiesCtxValue={ctxValue}>
     <BrowseFilters
       isSearching={false}
-      cqlQquery=""
       {...props}
     />
   </Harness>,

--- a/lib/BrowseFilters/BrowseFilters.test.js
+++ b/lib/BrowseFilters/BrowseFilters.test.js
@@ -6,8 +6,13 @@ import {
 import { runAxeTest } from '@folio/stripes-testing';
 
 import BrowseFilters from './BrowseFilters';
+import { useFacets } from '../queries';
+import {
+  FILTERS,
+  navigationSegments,
+  searchableIndexesValues,
+} from '../constants';
 import Harness from '../../test/jest/helpers/harness';
-import { FILTERS, navigationSegments } from '../constants';
 
 jest.mock('../queries', () => ({
   ...jest.requireActual('../queries'),
@@ -41,6 +46,7 @@ jest.mock('../MultiSelectionFacet', () => ({
 const mockSetFilters = jest.fn();
 
 const defaultCtxValue = {
+  searchIndex: searchableIndexesValues.PERSONAL_NAME,
   setFilters: mockSetFilters,
   filters: {
     headingType: ['val-a', 'val-b'],
@@ -119,5 +125,15 @@ describe('Given BrowseFilters', () => {
         rootNode: container,
       });
     });
+  });
+
+  it('should call useFacets with correct parameters', () => {
+    renderBrowseFilters();
+
+    expect(useFacets).toHaveBeenCalledWith(expect.objectContaining({
+      query: '(personalName all "*" or sftPersonalName all "*" or saftPersonalName all "*") and (headingType==("val-a" or "val-b")) and (subjectHeadings==("Other"))',
+      selectedFacets: ['sourceFileId'],
+      tenantId: null,
+    }));
   });
 });


### PR DESCRIPTION
## Description
Change query building process for Browse filters. Use `query=*` instead of `headingRef>=query or headingRef<query` as per BE recommendation

## Screenshots

https://github.com/user-attachments/assets/70749f62-19ac-4962-8164-4fd68e5073fb



## Issues
[UISAUTCOMP-140](http://folio-org.atlassian.net/browse/UISAUTCOMP-140)