### PR TITLE
UISAUTCOMP-143: Correct the `Children's subject heading` search query (follow-up).

### DIFF
--- a/lib/queries/utils/buildAdvancedSearchQuery.js
+++ b/lib/queries/utils/buildAdvancedSearchQuery.js
@@ -60,7 +60,7 @@ export const buildAdvancedSearchQuery = ({ searchOption, match, query, filters }
     [searchableIndexesValues.SUBJECT]: () => formatHeadingsQuery(indexData, fullTextQueryTemplate, filters),
     [searchableIndexesValues.CHILDREN_SUBJECT_HEADING]: {
       [EXACT_PHRASE]: '((keyword=="%{query}" or naturalId="%{query}") and subjectHeadings=="b")',
-      [CONTAINS_ALL]: '((keyword all "%{query}" or naturalId="%{query}") and subjectHeadings=="b")',
+      [CONTAINS_ALL]: '((keyword all "%{query}" or naturalId="%{query}" or identifiers.value=="%{query}") and subjectHeadings=="b")',
       [STARTS_WITH]: '((keyword all "%{query}*" or naturalId="%{query}*") and subjectHeadings=="b")',
       [CONTAINS_ANY]: '((keyword any "%{query}" or naturalId any "*%{query}*") and subjectHeadings=="b")',
     },

--- a/lib/queries/utils/buildQuery.js
+++ b/lib/queries/utils/buildQuery.js
@@ -67,7 +67,7 @@ const buildQuery = ({
   if (searchIndex === searchableIndexesValues.CHILDREN_SUBJECT_HEADING) {
     const childrenSubjectHeadingData = indexData[0];
 
-    return `((${searchableIndexesValues.KEYWORD} all "%{query}" or naturalId="%{query}") and ${childrenSubjectHeadingData.name}=="b")`;
+    return `((${searchableIndexesValues.KEYWORD} all "%{query}" or naturalId="%{query}" or identifiers.value=="%{query}") and ${childrenSubjectHeadingData.name}=="b")`;
   }
 
   if (searchIndex === searchableIndexesValues.IDENTIFIER) {

--- a/lib/queries/utils/buildQuery.test.js
+++ b/lib/queries/utils/buildQuery.test.js
@@ -113,7 +113,7 @@ describe('Given buildQuery', () => {
         query: 'somevalue',
       });
 
-      expect(query).toBe('((keyword all "%{query}" or naturalId="%{query}") and subjectHeadings=="b")');
+      expect(query).toBe('((keyword all "%{query}" or naturalId="%{query}" or identifiers.value=="%{query}") and subjectHeadings=="b")');
     });
   });
 


### PR DESCRIPTION
<!--
  If you have a relevant JIRA issue number, please put it in the issue title.
  Example: UIEH-57 Create example component

  TL;DR
    - https://www.youtube.com/watch?v=5aHmO_S8FQ4
    - http://www.olitreadwell.com/2016/05/22/how-to-write-great-pull-requests/
    - https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests
-->

## Purpose
Correct the `Children's subject heading` search query to be able to search by LCCN exact match (with spaces).
<!--
  Why are you making this change? There is nothing more important
  to provide to the reviewer and to future readers than the cause
  that gave rise to this pull request. Be careful to avoid circular
  statements like "the purpose is to change the font colors." and
  instead provide an explanation like "the current textual color
  palette does not provide enough contrast for certain classes of
  visual impairments."

  The purpose may seem self-evident to you now, but the standard to
  hold yourself to should be "can a developer parachuting into this
  project reconstruct the necessary context merely by reading this
  section."

  If you have a relevant JIRA issue, add a link directly to the issue URL here.
  Example: https://issues.folio.org/browse/UIEH-57
 -->

## Issues
[UISAUTCOMP-143](https://folio-org.atlassian.net/browse/UISAUTCOMP-143)

## Approach
<!--
 How does this change fulfill the purpose? It's best to talk
 high-level strategy and avoid code-splaining the commit history.

 Bad:
  Made a dark color of #333, a medium color of #ccc

 Good:
   This introduces three abstract contrast levels that developers can
   use: dark, medium, and light.

 The goal is not only to explain what you did, but help other
 developers *work* with your solution in the future.
-->

#### TODOS and Open Questions
<!-- OPTIONAL
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
-->

## Learning
<!-- OPTIONAL
  Help out not only your reviewer, but also your fellow developer!
  Sometimes there are key pieces of information that you used to come up
  with your solution. Don't let all that hard work go to waste! A
  pull request is a *perfect opportunity to share the learning that
  you did. Add links to blog posts, patterns, libraries or addons used
  to solve this problem.
-->

## Screenshots


https://github.com/user-attachments/assets/c8878ffc-5a92-4c3c-a0df-ff5e6544042b




<!-- OPTIONAL
 One picture is literally worth a thousand words. When the feature is
 an interaction, an animated GIF is best. Most of the time it helps to
 include "before" and "after" screenshots to quickly demonstrate the
 value of the feature.

 Here are some great tools to help you record gifs:

 Windows: https://getsharex.com/
 Mac: https://gifox.io/
-->
