### PR TITLE
UISAUTCOMP-152 `useAuthority` hook - use `expandAll=true` parameter to fetch authority metadata.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [6.1.0] (IN PROGRESS)
 
 - [UISAUTCOMP-151](https://folio-org.atlassian.net/browse/UISAUTCOMP-151) `useUsers` hook - accept a `tenantId` argument.
+- [UISAUTCOMP-152](https://folio-org.atlassian.net/browse/UISAUTCOMP-152) `useAuthority` hook - use `expandAll=true` parameter to fetch authority metadata.
 
 ## [6.0.1] (https://github.com/folio-org/stripes-authority-components/tree/v6.0.1) (2025-04-09)
 

--- a/lib/queries/useAuthority/useAuthority.js
+++ b/lib/queries/useAuthority/useAuthority.js
@@ -32,7 +32,7 @@ export const useAuthority = ({ recordId, tenantId, authRefType = null, headingRe
         .map((a, index) => {
           return ky.get(
             AUTHORITIES_API,
-            { searchParams: { ...searchParams, limit: AUTHORITY_CHUNK_SIZE, offset: index * AUTHORITY_CHUNK_SIZE } },
+            { searchParams: { ...searchParams, limit: AUTHORITY_CHUNK_SIZE, offset: index * AUTHORITY_CHUNK_SIZE, expandAll: true } },
           ).json();
         });
       const authorityBatches = await Promise.all(authorityBatchesPromises);

--- a/lib/queries/useAuthority/useAuthority.test.js
+++ b/lib/queries/useAuthority/useAuthority.test.js
@@ -53,7 +53,7 @@ describe('Given useAuthority', () => {
     await act(async () => !result.current.isLoading);
 
     expect(mockGet).toHaveBeenCalledWith('search/authorities', {
-      searchParams: { query: `(id==${recordId})`, limit: 500, offset: 0 },
+      searchParams: { query: `(id==${recordId})`, limit: 500, offset: 0, expandAll: true },
     });
   });
 });


### PR DESCRIPTION
## Description
`useAuthority` hook - use `expandAll=true` parameter to fetch authority metadata. Using this parameter also includes `subjectHeadings` value in the response, but it's not used on the UI yet

## Issues
[UISAUTCOMP-152](https://folio-org.atlassian.net/browse/UISAUTCOMP-152)