### PR TITLE
UISAUTCOMP-157 Update Keyword and LCCN search options to search Cancelled LCCN index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [UISAUTCOMP-151](https://folio-org.atlassian.net/browse/UISAUTCOMP-151) `useUsers` hook - accept a `tenantId` argument.
 - [UISAUTCOMP-155](https://folio-org.atlassian.net/browse/UISAUTCOMP-155) *BREAKING* Update for Split Search & Browse APIs.
+- [UISAUTCOMP-157](https://folio-org.atlassian.net/browse/UISAUTCOMP-157) Update Keyword and LCCN search options to search Cancelled LCCN index.
 
 ## [6.0.2] (https://github.com/folio-org/stripes-authority-components/tree/v6.0.2) (2025-06-02)
 

--- a/lib/constants/searchableIndexesMap.js
+++ b/lib/constants/searchableIndexesMap.js
@@ -12,6 +12,9 @@ export const searchableIndexesMap = {
   [searchableIndexesValues.LCCN]: [{
     name: 'lccn',
   }],
+  [searchableIndexesValues.CANCELED_LCCN]: [{
+    name: 'canceledLccn',
+  }],
   [searchableIndexesValues.PERSONAL_NAME]: [{
     name: 'personalName',
     plain: true,

--- a/lib/constants/searchableIndexesValues.js
+++ b/lib/constants/searchableIndexesValues.js
@@ -11,4 +11,5 @@ export const searchableIndexesValues = {
   GENRE: 'genre',
   ADVANCED_SEARCH: 'advancedSearch',
   LCCN: 'lccn',
+  CANCELED_LCCN: 'canceledLccn',
 };

--- a/lib/queries/useAuthorities/useAuthorities.test.js
+++ b/lib/queries/useAuthorities/useAuthorities.test.js
@@ -343,7 +343,7 @@ describe('Given useAuthorities', () => {
         result_ = result;
       });
 
-      expect(result_.current.query).toContain('lccn=="n  88173836" not ((identifiers.value any');
+      expect(result_.current.query).toContain('(lccn=="n  88173836" or canceledLccn=="n  88173836") not ((identifiers.value any');
     });
 
     describe('when the "Identifier (all)" search option is opted', () => {

--- a/lib/queries/utils/buildAdvancedSearchQuery.js
+++ b/lib/queries/utils/buildAdvancedSearchQuery.js
@@ -47,10 +47,10 @@ export const buildAdvancedSearchQuery = ({ searchOption, match, query, filters }
       return identifierTemplates[match];
     },
     [searchableIndexesValues.LCCN]: {
-      [EXACT_PHRASE]: 'lccn=="%{query}"',
-      [CONTAINS_ALL]: 'lccn="*%{query}*"',
-      [STARTS_WITH]: 'lccn="%{query}*"',
-      [CONTAINS_ANY]: 'lccn any "*%{query}*"',
+      [EXACT_PHRASE]: '(lccn=="%{query}" or canceledLccn=="%{query}")',
+      [CONTAINS_ALL]: '(lccn="*%{query}*" or canceledLccn="*%{query}*")',
+      [STARTS_WITH]: '(lccn="%{query}*" or canceledLccn="%{query}*")',
+      [CONTAINS_ANY]: '(lccn any "*%{query}*" or canceledLccn any "*%{query}*")',
     },
     [searchableIndexesValues.PERSONAL_NAME]: () => formatHeadingsQuery(indexData, fullTextQueryTemplate, filters),
     [searchableIndexesValues.CORPORATE_CONFERENCE_NAME]: () => formatHeadingsQuery(indexData, fullTextQueryTemplate, filters),

--- a/lib/queries/utils/buildQuery.js
+++ b/lib/queries/utils/buildQuery.js
@@ -79,9 +79,7 @@ const buildQuery = ({
   }
 
   if (searchIndex === searchableIndexesValues.LCCN) {
-    const lccn = indexData[0].name;
-
-    return `${lccn}="${query.trim()}"`;
+    return `(lccn="${query.trim()}" or canceledLccn="${query.trim()}")`;
   }
 
   const queryTemplate = name => `${name} ${comparator} "%{query}"`;

--- a/lib/queries/utils/buildQuery.test.js
+++ b/lib/queries/utils/buildQuery.test.js
@@ -102,7 +102,7 @@ describe('Given buildQuery', () => {
         query: ' n  88173836 ',
       });
 
-      expect(query).toBe('lccn="n  88173836"');
+      expect(query).toBe('(lccn="n  88173836" or canceledLccn="n  88173836")');
     });
   });
 


### PR DESCRIPTION
## Description
LCCN index has been split into two: lccn and canceledLccn. We need to change our search parameters to search by both.

## Issues
[UISAUTCOMP-157](https://folio-org.atlassian.net/browse/UISAUTCOMP-157)