### PR TITLE
UISAUTCOMP-170 `useAuthority` - wrap `react-query`'s `refetch` function to return a single record.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - [UISAUTCOMP-167](https://folio-org.atlassian.net/browse/UISAUTCOMP-167) MARC authority filters typeahead uses "starts with" instead of "contains"
 - [UISAUTCOMP-168](https://folio-org.atlassian.net/browse/UISAUTCOMP-168) Return `refetch` function from `useAuthority` hook.
 - [UISAUTCOMP-169](https://folio-org.atlassian.net/browse/UISAUTCOMP-169) MARC authority hit list does not stay on selected entry after "quickmarc" pane closing.
+- [UISAUTCOMP-169](https://folio-org.atlassian.net/browse/UISAUTCOMP-169) MARC authority hit list does not stay on selected entry after "quickmarc" pane closing.
+- [UISAUTCOMP-170](https://folio-org.atlassian.net/browse/UISAUTCOMP-170) `useAuthority` - wrap `react-query`'s `refetch` function to return a single record.
 
 ## [6.0.3] (https://github.com/folio-org/stripes-authority-components/tree/v6.0.3) (2025-09-17)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@
 - [UISAUTCOMP-167](https://folio-org.atlassian.net/browse/UISAUTCOMP-167) MARC authority filters typeahead uses "starts with" instead of "contains"
 - [UISAUTCOMP-168](https://folio-org.atlassian.net/browse/UISAUTCOMP-168) Return `refetch` function from `useAuthority` hook.
 - [UISAUTCOMP-169](https://folio-org.atlassian.net/browse/UISAUTCOMP-169) MARC authority hit list does not stay on selected entry after "quickmarc" pane closing.
-- [UISAUTCOMP-169](https://folio-org.atlassian.net/browse/UISAUTCOMP-169) MARC authority hit list does not stay on selected entry after "quickmarc" pane closing.
 - [UISAUTCOMP-170](https://folio-org.atlassian.net/browse/UISAUTCOMP-170) `useAuthority` - wrap `react-query`'s `refetch` function to return a single record.
 
 ## [6.0.3] (https://github.com/folio-org/stripes-authority-components/tree/v6.0.3) (2025-09-17)

--- a/lib/queries/useAuthority/useAuthority.js
+++ b/lib/queries/useAuthority/useAuthority.js
@@ -46,19 +46,29 @@ export const useAuthority = ({ recordId, tenantId, authRefType = null, headingRe
     },
   );
 
-  let authorityByAuthRefType = null;
+  const retrieveSingeRecordFromResults = results => {
+    let authorityByAuthRefType = null;
 
-  // can only be one Authorized record - can ignore headingRef
-  if (authRefType === AUTH_REF_TYPES.AUTHORIZED) {
-    authorityByAuthRefType = find(data, matches({ authRefType }));
-  } else {
-    authorityByAuthRefType = filter(data, matches({ authRefType, headingRef }))[0];
-  }
+    // can only be one Authorized record - can ignore headingRef
+    if (authRefType === AUTH_REF_TYPES.AUTHORIZED) {
+      authorityByAuthRefType = find(results, matches({ authRefType }));
+    } else {
+      authorityByAuthRefType = filter(results, matches({ authRefType, headingRef }))[0];
+    }
+
+    return authorityByAuthRefType || results[0];
+  };
+
+  const refetchAndReturnSingleRecord = async () => {
+    const { data: _data } = await refetch();
+
+    return retrieveSingeRecordFromResults(_data);
+  };
 
   return ({
-    data: authorityByAuthRefType || data[0],
+    data: retrieveSingeRecordFromResults(data),
     isLoading: isFetching,
     allData: data,
-    refetch,
+    fetchAuthority: refetchAndReturnSingleRecord,
   });
 };

--- a/lib/queries/useAuthority/useAuthority.js
+++ b/lib/queries/useAuthority/useAuthority.js
@@ -46,7 +46,7 @@ export const useAuthority = ({ recordId, tenantId, authRefType = null, headingRe
     },
   );
 
-  const retrieveSingeRecordFromResults = results => {
+  const retrieveSingleRecordFromResults = results => {
     let authorityByAuthRefType = null;
 
     // can only be one Authorized record - can ignore headingRef
@@ -62,11 +62,11 @@ export const useAuthority = ({ recordId, tenantId, authRefType = null, headingRe
   const refetchAndReturnSingleRecord = async () => {
     const { data: _data } = await refetch();
 
-    return retrieveSingeRecordFromResults(_data);
+    return retrieveSingleRecordFromResults(_data);
   };
 
   return ({
-    data: retrieveSingeRecordFromResults(data),
+    data: retrieveSingleRecordFromResults(data),
     isLoading: isFetching,
     allData: data,
     fetchAuthority: refetchAndReturnSingleRecord,


### PR DESCRIPTION
## Description
We have a bug in quickMARC where when updating a linked MARC Auhority record a confirmation pop-up doesn't show.
The root cause is in returning an array instead of a single record from `refetch` function.
MARC Authorities app uses `refetch` to fetch an opened Authority record, and so it expects a single record, but in `useAuthority` we're fetching records via Authority search API, which returns an array.
So we need to apply the same logic for `refetch` results as we have for regular hook's returned value

## Screenshots

https://github.com/user-attachments/assets/c88f66b4-dc4f-4c6a-9f41-94b1c3725932


## Issues
[UISAUTCOMP-170](https://folio-org.atlassian.net/browse/UISAUTCOMP-170)

## Related PRs
https://github.com/folio-org/ui-marc-authorities/pull/497