### PR TITLE
UISAUTCOMP-173 `SearchResultsList` - remove default `onHeaderClick` prop value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change history for stripes-authority-components
 
+## [7.1.0] (IN PROGRESS)
+
+- [UISAUTCOMP-173](https://folio-org.atlassian.net/browse/UISAUTCOMP-173) `SearchResultsList` - remove default `onHeaderClick` prop value.
+
 ## [7.0.0] (https://github.com/folio-org/stripes-authority-components/tree/v7.0.0) (2026-04-17)
 
 - [UISAUTCOMP-151](https://folio-org.atlassian.net/browse/UISAUTCOMP-151) `useUsers` hook - accept a `tenantId` argument.

--- a/lib/SearchResultsList/SearchResultsList.js
+++ b/lib/SearchResultsList/SearchResultsList.js
@@ -43,7 +43,7 @@ const propTypes = {
   loaded: PropTypes.bool.isRequired,
   loading: PropTypes.bool.isRequired,
   nonInteractiveHeaders: PropTypes.arrayOf(PropTypes.string),
-  onHeaderClick: PropTypes.func, // don't give this one a default value - MCL has some logic checking for undefined prop value
+  onHeaderClick: PropTypes.func,
   onNeedMoreData: PropTypes.func.isRequired,
   onRowFocus: PropTypes.func,
   pageSize: PropTypes.number.isRequired,
@@ -83,7 +83,7 @@ const SearchResultsList = ({
   hasNextPage = null,
   hasPrevPage = null,
   onRowFocus = noop,
-  onHeaderClick,
+  onHeaderClick, // don't give this one a default value - MCL has some logic checking for undefined prop value
   showSortIndicator = false,
   sortableColumns = [],
   sortedColumn = null,

--- a/lib/SearchResultsList/SearchResultsList.js
+++ b/lib/SearchResultsList/SearchResultsList.js
@@ -43,7 +43,7 @@ const propTypes = {
   loaded: PropTypes.bool.isRequired,
   loading: PropTypes.bool.isRequired,
   nonInteractiveHeaders: PropTypes.arrayOf(PropTypes.string),
-  onHeaderClick: PropTypes.func,
+  onHeaderClick: PropTypes.func, // don't give this one a default value - MCL has some logic checking for undefined prop value
   onNeedMoreData: PropTypes.func.isRequired,
   onRowFocus: PropTypes.func,
   pageSize: PropTypes.number.isRequired,
@@ -83,7 +83,7 @@ const SearchResultsList = ({
   hasNextPage = null,
   hasPrevPage = null,
   onRowFocus = noop,
-  onHeaderClick = noop,
+  onHeaderClick,
   showSortIndicator = false,
   sortableColumns = [],
   sortedColumn = null,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-authority-components",
-  "version": "7.0.0",
+  "version": "7.1.0",
   "description": "Component library for Stripes Authority modules",
   "repository": "https://github.com/folio-org/stripes-authority-components",
   "main": "index.js",


### PR DESCRIPTION
## Description
MCL has some logic that checks if `onHeaderClick` prop is not falsey - it thinks the MCL headers are interactive and makes them into buttons.
We started passing `noop` as a default value a few months ago, which broke tests in ui-plugin-find-authority, but we didn't catch that because we didn't have any functional commits into that repo the whole Trillium release.
Functionally it's not a huge issue - it just shows the hand icon when hovering over the headers. It's just the failing tests that are the real issue.

## Issues
[UISAUTCOMP-173](https://folio-org.atlassian.net/browse/UISAUTCOMP-173)