### PR TITLE
UISAUTCOMP-174 `useAuthority` - refetch when results are empty.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [7.1.0] (IN PROGRESS)
 
 - [UISAUTCOMP-173](https://folio-org.atlassian.net/browse/UISAUTCOMP-173) `SearchResultsList` - remove default `onHeaderClick` prop value.
+- [UISAUTCOMP-174](https://folio-org.atlassian.net/browse/UISAUTCOMP-174) `useAuthority` - refetch when results are empty.
 
 ## [7.0.0] (https://github.com/folio-org/stripes-authority-components/tree/v7.0.0) (2026-04-17)
 

--- a/lib/queries/useAuthority/useAuthority.js
+++ b/lib/queries/useAuthority/useAuthority.js
@@ -10,10 +10,13 @@ import {
 
 import { AUTH_REF_TYPES } from '../../constants';
 
+const MAX_REFETCH_COUNT = 5;
+const REFETCH_INTERVAL = 3000;
+
 const AUTHORITIES_API = 'search/authorities';
 const AUTHORITY_CHUNK_SIZE = 500;
 
-export const useAuthority = ({ recordId, tenantId, authRefType = null, headingRef = null }, { onError } = {}) => {
+export const useAuthority = ({ recordId, tenantId, authRefType = null, headingRef = null, refetchOnEmptyResults = false }, { onError } = {}) => {
   const [namespace] = useNamespace();
   const ky = useOkapiKy({ tenant: tenantId });
 
@@ -43,6 +46,17 @@ export const useAuthority = ({ recordId, tenantId, authRefType = null, headingRe
     },
     {
       cacheTime:0,
+      refetchInterval: (_data, query) => {
+        if (!refetchOnEmptyResults) {
+          return false;
+        }
+
+        if (_data?.length || query.state.dataUpdateCount >= MAX_REFETCH_COUNT) {
+          return false;
+        }
+
+        return REFETCH_INTERVAL;
+      },
     },
   );
 


### PR DESCRIPTION
## Description
`useAuthority` - refetch when results are empty and `refetchOnEmptyResults` is true

## Issues
[UISAUTCOMP-174](https://folio-org.atlassian.net/browse/UISAUTCOMP-174)

## Related PRs
https://github.com/folio-org/ui-marc-authorities/pull/503