### PR TITLE
UISAUTCOMP-176 Apply search index and query when applying filters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## [7.1.0] (IN PROGRESS)
 
+- [UISAUTCOMP-176](https://folio-org.atlassian.net/browse/UISAUTCOMP-176) Apply search index and query when applying filters.
 
 ## [7.0.1] (https://github.com/folio-org/stripes-authority-components/tree/v7.0.1) (2026-05-28)
 

--- a/lib/SearchFilters/SearchFilters.js
+++ b/lib/SearchFilters/SearchFilters.js
@@ -62,8 +62,7 @@ const SearchFilters = ({
 
   const applyFilters = useCallback(({ name, values }) => {
     updateFilters({ name, values, setFilters });
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [setFilters]);
 
   const isVisible = filter => !excludedFilters.includes(filter);
 

--- a/lib/context/AuthoritiesSearchContext.js
+++ b/lib/context/AuthoritiesSearchContext.js
@@ -167,6 +167,10 @@ const AuthoritiesSearchContextProvider = ({
     sortedColumn,
   ]);
 
+  // a wrapper for internal `_setFilters` setter to copy values from `searchDropdownValue` and `searchInputValue`,
+  // which are simply storing the state of the inputs to the `searchQuery` and `searchIndex`,
+  // which are actually used in a query for Authorities.
+  // the internal `_setFilters` should not be exposed to context consumers.
   const setFilters = useCallback(_filters => {
     setSearchIndex(searchDropdownValue);
     setSearchQuery(searchInputValue);

--- a/lib/context/AuthoritiesSearchContext.js
+++ b/lib/context/AuthoritiesSearchContext.js
@@ -93,7 +93,7 @@ const AuthoritiesSearchContextProvider = ({
   const [searchQuery, setSearchQuery] = useState(initialSearchQuery);
   const [searchDropdownValue, setSearchDropdownValue] = useState(initialDropdownValue);
   const [searchIndex, setSearchIndex] = useState(initialSearchIndex);
-  const [filters, setFilters] = useState(getInitialFilters());
+  const [filters, _setFilters] = useState(getInitialFilters()); // eslint-disable-line react/hook-use-state
   const [offset, setOffset] = useState(initialOffset);
   const [browsePage, setBrowsePage] = useState(initialBrowsePage);
   const [browsePageQuery, setBrowsePageQuery] = useState(initialBrowsePageQuery);
@@ -167,6 +167,12 @@ const AuthoritiesSearchContextProvider = ({
     sortedColumn,
   ]);
 
+  const setFilters = useCallback(_filters => {
+    setSearchIndex(searchDropdownValue);
+    setSearchQuery(searchInputValue);
+    _setFilters(_filters);
+  }, [_setFilters, setSearchIndex, searchDropdownValue, setSearchQuery, searchInputValue]);
+
   const setNavigationSegmentValue = value => {
     const params = paramsBySegment.current[value];
 
@@ -199,7 +205,9 @@ const AuthoritiesSearchContextProvider = ({
     setSearchIndex(defaultDropdownValueBySegment[navigationSegmentValue]);
     setSortOrder(sortOrders.ASC);
     setSortedColumn('');
-    setFilters({});
+    // use _setFilters instead of setFilters because setFilters also calls setSearchQuery and setSearchIndex
+    // and it would overwrite our changes above
+    _setFilters({});
     setIsGoingToBaseURL(true);
     setAdvancedSearchDefaultSearch(null);
     paramsBySegment.current[navigationSegmentValue] = null;

--- a/lib/context/AuthoritiesSearchContext.test.js
+++ b/lib/context/AuthoritiesSearchContext.test.js
@@ -11,6 +11,11 @@ import {
 } from './AuthoritiesSearchContext';
 import { navigationSegments } from '../constants';
 
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: jest.fn().mockReturnValue({ search: '?segment=search' }),
+}));
+
 const TestingComponent = () => {
   const { setFilters, searchQuery, searchIndex } = useContext(AuthoritiesSearchContext);
 

--- a/lib/context/AuthoritiesSearchContext.test.js
+++ b/lib/context/AuthoritiesSearchContext.test.js
@@ -1,0 +1,59 @@
+import { useContext } from 'react';
+
+import {
+  fireEvent,
+  render,
+} from '@folio/jest-config-stripes/testing-library/react';
+
+import {
+  AuthoritiesSearchContext,
+  AuthoritiesSearchContextProvider,
+} from './AuthoritiesSearchContext';
+import { navigationSegments } from '../constants';
+
+const TestingComponent = () => {
+  const { setFilters, searchQuery, searchIndex } = useContext(AuthoritiesSearchContext);
+
+  return (
+    <>
+      <span data-testid="searchIndex">{searchIndex}</span>
+      <span data-testid="searchQuery">{searchQuery}</span>
+      <button
+        type="button"
+        onClick={() => setFilters({ filter1: ['filter1value'] })}
+      >
+        Set filters
+      </button>
+    </>
+  );
+};
+
+const getComponent = ({
+  contextInitialValues = {},
+  ...props
+} = {}) => (
+  <AuthoritiesSearchContextProvider initialValues={contextInitialValues}>
+    <TestingComponent {...props} />
+  </AuthoritiesSearchContextProvider>
+);
+
+describe('Given AuthoritiesSearchContext', () => {
+  describe('when setting filters via setFilters', () => {
+    it('should also copy search index and search query to be applied in search', () => {
+      const { getByTestId, getByRole, rerender } = render(getComponent({
+        contextInitialValues: {
+          [navigationSegments.search]: {
+            dropdownValue: 'personalName',
+            searchInputValue: 'test',
+          },
+        },
+      }));
+
+      fireEvent.click(getByRole('button', { name: 'Set filters' }));
+      rerender(getComponent());
+
+      expect(getByTestId('searchIndex')).toHaveTextContent('personalName');
+      expect(getByTestId('searchQuery')).toHaveTextContent('test');
+    });
+  });
+});

--- a/lib/context/SelectedAuthorityRecordContextProvider.test.js
+++ b/lib/context/SelectedAuthorityRecordContextProvider.test.js
@@ -50,7 +50,7 @@ const getComponent = ({
 
 const customRender = (props) => render(getComponent(props));
 
-describe('Given Provider', () => {
+describe('Given SelectedAuthorityRecordContextProvider', () => {
   describe('when the readParamsFromUrl is true', () => {
     it('should store selected authority record for Search and Browse searches separately', () => {
       const props = { readParamsFromUrl: true };


### PR DESCRIPTION
## Description
Apply search index and query when applying filters.
In other Folio apps when a user enters some search query, and without clicking on "Search" they then select some filters - the entered query is applied.
In MARC Authorities search it's not happening, and this PR addresses this issue.
The approach is to add a wrapper to a `setFilters` state setter to also copy values from `searchDropdownValue` and `searchInputValue`, which are simply storing the state of the inputs to the `searchQuery` and `searchIndex`, which are actually used in a query for Authorities.
The internal `_setFilters` should not be exposed to context consumers

## Screenshots

https://github.com/user-attachments/assets/2c5cf61f-5d6b-4aa4-9ef6-e32bad2b99fa



## Issues
[UISAUTCOMP-176](https://folio-org.atlassian.net/browse/UISAUTCOMP-176)