### PR TITLE
UISAUTCOMP-150 MARC authority | Hit "Enter" keyboard button must "click" on button elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [7.1.0] (IN PROGRESS)
 
 - [UISAUTCOMP-176](https://folio-org.atlassian.net/browse/UISAUTCOMP-176) Apply search index and query when applying filters.
+- [UISAUTCOMP-150](https://folio-org.atlassian.net/browse/UISAUTCOMP-150) MARC authority | Hit "Enter" keyboard button must "click" on button elements.
 
 ## [7.0.1] (https://github.com/folio-org/stripes-authority-components/tree/v7.0.1) (2026-05-28)
 

--- a/lib/AuthoritiesSearchForm/AuthoritiesSearchForm.js
+++ b/lib/AuthoritiesSearchForm/AuthoritiesSearchForm.js
@@ -12,7 +12,6 @@ import {
   Button,
   Icon,
   AdvancedSearch,
-  HotKeys,
 } from '@folio/stripes/components';
 import { advancedSearchQueryToRows } from '@folio/stripes/smart-components';
 
@@ -119,18 +118,6 @@ const AuthoritiesSearchForm = ({
   const isFiltersApplied = Object.values(filters).find(value => value.length > 0);
   const isResetAllButtonDisabled = (!searchInputValue && !isFiltersApplied) || isAuthoritiesLoading;
 
-  const hotKeys = {
-    search: ['enter'],
-  };
-
-  const getHandlers = rowState => ({
-    search:e => {
-      if (isSearchButtonDisabled) return e.preventDefault();
-
-      return onSubmitSearch(e, rowState);
-    },
-  });
-
   const advancedSearchQueryBuilder = rows => {
     return rows.reduce((formattedQuery, row, index) => {
       const rowCondition = `${row.searchOption} ${row.match} ${row.query}`;
@@ -161,67 +148,61 @@ const AuthoritiesSearchForm = ({
       queryToRow={row => advancedSearchQueryToRows(row.query)}
     >
       {({ resetRows, rowState }) => (
-        <HotKeys
-          attach={document.body}
-          keyMap={hotKeys}
-          handlers={getHandlers(rowState)}
-        >
-          <form onSubmit={e => onSubmitSearch(e, rowState)}>
-            <FilterNavigation />
-            <div className={css.searchGroupWrap}>
-              <SearchTextareaField
-                textAreaRef={searchInputRef}
-                autoFocus
-                rows="1"
-                name="query"
-                id="textarea-authorities-search"
-                className={css.searchField}
-                placeholder={placeholderValue}
-                searchableIndexes={searchableIndexes}
-                onSubmitSearch={onSubmitSearch}
-              />
+        <form onSubmit={e => onSubmitSearch(e, rowState)}>
+          <FilterNavigation />
+          <div className={css.searchGroupWrap}>
+            <SearchTextareaField
+              textAreaRef={searchInputRef}
+              autoFocus
+              rows="1"
+              name="query"
+              id="textarea-authorities-search"
+              className={css.searchField}
+              placeholder={placeholderValue}
+              searchableIndexes={searchableIndexes}
+              onSubmitSearch={e => onSubmitSearch(e, rowState)}
+            />
+            <Button
+              id="submit-authorities-search"
+              data-testid="submit-authorities-search"
+              type="submit"
+              buttonStyle="primary"
+              fullWidth
+              marginBottom0
+              disabled={isSearchButtonDisabled}
+            >
+              {intl.formatMessage({ id: 'stripes-authority-components.label.search' })}
+            </Button>
+          </div>
+          <div className={css.resetAndAdvancedSearchWrapper}>
+            <Button
+              buttonStyle="none"
+              buttonClass={css.resetButton}
+              id="clickable-reset-all"
+              fullWidth
+              marginBottom0={hasAdvancedSearch}
+              disabled={isResetAllButtonDisabled}
+              onClick={() => {
+                resetRows();
+                handleResetAll();
+              }}
+            >
+              <Icon icon="times-circle-solid">
+                {intl.formatMessage({ id: 'stripes-smart-components.resetAll' })}
+              </Icon>
+            </Button>
+            {hasAdvancedSearch && navigationSegmentValue !== navigationSegments.browse && (
               <Button
-                id="submit-authorities-search"
-                data-testid="submit-authorities-search"
-                type="submit"
-                buttonStyle="primary"
+                buttonClass={css.advancedSearchButton}
                 fullWidth
                 marginBottom0
-                disabled={isSearchButtonDisabled}
+                onClick={() => setIsAdvancedSearchOpen(true)}
               >
-                {intl.formatMessage({ id: 'stripes-authority-components.label.search' })}
+                {intl.formatMessage({ id: 'stripes-components.advancedSearch.button' })}
               </Button>
-            </div>
-            <div className={css.resetAndAdvancedSearchWrapper}>
-              <Button
-                buttonStyle="none"
-                buttonClass={css.resetButton}
-                id="clickable-reset-all"
-                fullWidth
-                marginBottom0={hasAdvancedSearch}
-                disabled={isResetAllButtonDisabled}
-                onClick={() => {
-                  resetRows();
-                  handleResetAll();
-                }}
-              >
-                <Icon icon="times-circle-solid">
-                  {intl.formatMessage({ id: 'stripes-smart-components.resetAll' })}
-                </Icon>
-              </Button>
-              {hasAdvancedSearch && navigationSegmentValue !== navigationSegments.browse && (
-                <Button
-                  buttonClass={css.advancedSearchButton}
-                  fullWidth
-                  marginBottom0
-                  onClick={() => setIsAdvancedSearchOpen(true)}
-                >
-                  {intl.formatMessage({ id: 'stripes-components.advancedSearch.button' })}
-                </Button>
-              )}
-            </div>
-          </form>
-        </HotKeys>
+            )}
+          </div>
+        </form>
       )}
     </AdvancedSearch>
   );

--- a/lib/SearchTextareaField/SearchTextareaField.js
+++ b/lib/SearchTextareaField/SearchTextareaField.js
@@ -1,6 +1,7 @@
 import {
   useEffect,
   useContext,
+  useCallback,
 } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
@@ -65,6 +66,14 @@ const SearchTextareaField = ({
     textAreaRef.current.style.height = `${textAreaRef.current.scrollHeight}px`;
   };
 
+  const handleKeyDown = useCallback(e => {
+    // if pressed Enter key
+    if (e.keyCode === 13 && !e.shiftKey) {
+      e.preventDefault();
+      onSubmitSearch();
+    }
+  }, [onSubmitSearch]);
+
   useEffect(() => {
     fitTextBoxToContent();
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -101,6 +110,7 @@ const SearchTextareaField = ({
         loading={loading}
         lockWidth
         onChange={e => setSearchInputValue(e.target.value)}
+        onKeyDown={handleKeyDown}
         type="search"
         value={searchInputValue || ''}
         readOnly={loading || rest.readOnly}


### PR DESCRIPTION
## Description
It seems that `<HotKeys>` is catching all keypress events, and not letting buttons and other elements default handling to occur.
Passing a reference to the form alone doesn't help in this situation, because we have elements within the form that shouldn't submit it, but open modals, switch tabs etc.
So instead of using `<HotKeys>` we can define our own `onKeyDown` handler on the search query input and submit the form when we detect an `Enter` key press. And the rest of the default `Enter` key presses on buttons will work as expected.

## Issues
[UISAUTCOMP-150](https://folio-org.atlassian.net/browse/UISAUTCOMP-150)