### PR TITLE
UISAUTCOMP-177 Use `_setFilters` instead of `setFilters` when switching navigation segments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## [7.1.0] (IN PROGRESS)
 
 - [UISAUTCOMP-176](https://folio-org.atlassian.net/browse/UISAUTCOMP-176) Apply search index and query when applying filters.
+- [UISAUTCOMP-150](https://folio-org.atlassian.net/browse/UISAUTCOMP-150) MARC authority | Hit "Enter" keyboard button must "click" on button elements.
+- [UISAUTCOMP-177](https://folio-org.atlassian.net/browse/UISAUTCOMP-177) Fix Incorrect search option used for search when switching between browse and search.
 
 ## [7.0.1] (https://github.com/folio-org/stripes-authority-components/tree/v7.0.1) (2026-05-28)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## [7.1.0] (IN PROGRESS)
 
 - [UISAUTCOMP-176](https://folio-org.atlassian.net/browse/UISAUTCOMP-176) Apply search index and query when applying filters.
-- [UISAUTCOMP-150](https://folio-org.atlassian.net/browse/UISAUTCOMP-150) MARC authority | Hit "Enter" keyboard button must "click" on button elements.
 - [UISAUTCOMP-177](https://folio-org.atlassian.net/browse/UISAUTCOMP-177) Fix Incorrect search option used for search when switching between browse and search.
 
 ## [7.0.1] (https://github.com/folio-org/stripes-authority-components/tree/v7.0.1) (2026-05-28)

--- a/lib/context/AuthoritiesSearchContext.js
+++ b/lib/context/AuthoritiesSearchContext.js
@@ -182,7 +182,7 @@ const AuthoritiesSearchContextProvider = ({
 
     setSearchDropdownValue((params?.searchDropdownValue ?? initialValues[value]?.dropdownValue) || defaultDropdownValueBySegment[value]);
     setSearchIndex((params?.searchIndex ?? initialValues[value]?.searchIndex) || defaultDropdownValueBySegment[value]);
-    setFilters(params?.filters || initialValues[value]?.filters || {});
+    _setFilters(params?.filters || initialValues[value]?.filters || {});
     setSearchInputValue(params?.searchInputValue || '');
     setSearchQuery(params?.searchQuery || '');
     setIsGoingToBaseURL(true);

--- a/lib/context/AuthoritiesSearchContext.test.js
+++ b/lib/context/AuthoritiesSearchContext.test.js
@@ -1,4 +1,5 @@
 import { useContext } from 'react';
+import { useLocation } from 'react-router-dom';
 
 import {
   fireEvent,
@@ -9,7 +10,11 @@ import {
   AuthoritiesSearchContext,
   AuthoritiesSearchContextProvider,
 } from './AuthoritiesSearchContext';
-import { navigationSegments } from '../constants';
+import {
+  navigationSegments,
+  searchableIndexesValues,
+  sortOrders,
+} from '../constants';
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -17,17 +22,46 @@ jest.mock('react-router-dom', () => ({
 }));
 
 const TestingComponent = () => {
-  const { setFilters, searchQuery, searchIndex } = useContext(AuthoritiesSearchContext);
+  const ctx = useContext(AuthoritiesSearchContext);
 
   return (
     <>
-      <span data-testid="searchIndex">{searchIndex}</span>
-      <span data-testid="searchQuery">{searchQuery}</span>
+      <span data-testid="searchInputValue">{ctx.searchInputValue}</span>
+      <span data-testid="searchQuery">{ctx.searchQuery}</span>
+      <span data-testid="searchDropdownValue">{ctx.searchDropdownValue}</span>
+      <span data-testid="searchIndex">{ctx.searchIndex}</span>
+      <span data-testid="filters">{JSON.stringify(ctx.filters)}</span>
+      <span data-testid="offset">{ctx.offset}</span>
+      <span data-testid="browsePage">{ctx.browsePage}</span>
+      <span data-testid="browsePageQuery">{ctx.browsePageQuery}</span>
+      <span data-testid="sortOrder">{ctx.sortOrder}</span>
+      <span data-testid="sortedColumn">{ctx.sortedColumn}</span>
+      <span data-testid="navigationSegmentValue">{ctx.navigationSegmentValue}</span>
+      <span data-testid="isGoingToBaseURL">{String(ctx.isGoingToBaseURL)}</span>
+
       <button
         type="button"
-        onClick={() => setFilters({ filter1: ['filter1value'] })}
+        onClick={() => ctx.setFilters({ filter1: ['filter1value'] })}
       >
         Set filters
+      </button>
+      <button
+        type="button"
+        onClick={() => ctx.setNavigationSegmentValue(navigationSegments.browse)}
+      >
+        Go to browse
+      </button>
+      <button
+        type="button"
+        onClick={() => ctx.setNavigationSegmentValue(navigationSegments.search)}
+      >
+        Go to search
+      </button>
+      <button
+        type="button"
+        onClick={() => ctx.resetAll()}
+      >
+        Reset all
       </button>
     </>
   );
@@ -35,14 +69,21 @@ const TestingComponent = () => {
 
 const getComponent = ({
   contextInitialValues = {},
-  ...props
+  readParamsFromUrl,
 } = {}) => (
-  <AuthoritiesSearchContextProvider initialValues={contextInitialValues}>
-    <TestingComponent {...props} />
+  <AuthoritiesSearchContextProvider
+    initialValues={contextInitialValues}
+    readParamsFromUrl={readParamsFromUrl}
+  >
+    <TestingComponent />
   </AuthoritiesSearchContextProvider>
 );
 
 describe('Given AuthoritiesSearchContext', () => {
+  beforeEach(() => {
+    useLocation.mockReturnValue({ search: '?segment=search' });
+  });
+
   describe('when setting filters via setFilters', () => {
     it('should also copy search index and search query to be applied in search', () => {
       const { getByTestId, getByRole, rerender } = render(getComponent({
@@ -59,6 +100,150 @@ describe('Given AuthoritiesSearchContext', () => {
 
       expect(getByTestId('searchIndex')).toHaveTextContent('personalName');
       expect(getByTestId('searchQuery')).toHaveTextContent('test');
+    });
+  });
+
+  describe('when the provider is initialized', () => {
+    describe('and the URL has search params', () => {
+      it('should initialize state from the URL', () => {
+        useLocation.mockReturnValue({
+          search: '?segment=search&qindex=personalNameTitle&query=abc&offset=20&sort=-headingRef',
+        });
+
+        const { getByTestId } = render(getComponent());
+
+        expect(getByTestId('navigationSegmentValue')).toHaveTextContent(navigationSegments.search);
+        expect(getByTestId('searchIndex')).toHaveTextContent('personalNameTitle');
+        expect(getByTestId('searchDropdownValue')).toHaveTextContent('personalNameTitle');
+        expect(getByTestId('searchQuery')).toHaveTextContent('abc');
+        expect(getByTestId('searchInputValue')).toHaveTextContent('abc');
+        expect(getByTestId('offset')).toHaveTextContent('20');
+        expect(getByTestId('sortOrder')).toHaveTextContent(sortOrders.DES);
+        expect(getByTestId('sortedColumn')).toHaveTextContent('headingRef');
+      });
+    });
+
+    describe('and readParamsFromUrl is false', () => {
+      it('should ignore URL params and fall back to defaults', () => {
+        useLocation.mockReturnValue({
+          search: '?segment=search&qindex=personalNameTitle&query=abc',
+        });
+
+        const { getByTestId } = render(getComponent({ readParamsFromUrl: false }));
+
+        expect(getByTestId('searchIndex')).toHaveTextContent(searchableIndexesValues.KEYWORD);
+        expect(getByTestId('searchQuery').textContent).toBe('');
+      });
+    });
+
+    describe('and the URL is empty but initialValues are provided', () => {
+      it('should initialize state from initialValues', () => {
+        useLocation.mockReturnValue({ search: '' });
+
+        const { getByTestId } = render(getComponent({
+          contextInitialValues: {
+            segment: navigationSegments.browse,
+            [navigationSegments.browse]: {
+              dropdownValue: 'childrenSubjectHeading',
+              searchIndex: 'childrenSubjectHeading',
+              searchInputValue: 'foo',
+              searchQuery: 'foo',
+            },
+          },
+        }));
+
+        expect(getByTestId('navigationSegmentValue')).toHaveTextContent(navigationSegments.browse);
+        expect(getByTestId('searchDropdownValue')).toHaveTextContent('childrenSubjectHeading');
+        expect(getByTestId('searchIndex')).toHaveTextContent('childrenSubjectHeading');
+        expect(getByTestId('searchQuery')).toHaveTextContent('foo');
+      });
+    });
+  });
+
+  describe('when switching between segments', () => {
+    describe('and no params were stored for the target segment', () => {
+      it('should apply default values for the target segment', () => {
+        const { getByTestId, getByRole } = render(getComponent());
+
+        fireEvent.click(getByRole('button', { name: 'Go to browse' }));
+
+        expect(getByTestId('navigationSegmentValue')).toHaveTextContent(navigationSegments.browse);
+        expect(getByTestId('searchDropdownValue').textContent).toBe('');
+        expect(getByTestId('searchIndex').textContent).toBe('');
+        expect(getByTestId('searchQuery').textContent).toBe('');
+        expect(getByTestId('offset')).toHaveTextContent('0');
+        expect(getByTestId('sortOrder')).toHaveTextContent(sortOrders.ASC);
+        expect(getByTestId('isGoingToBaseURL')).toHaveTextContent('true');
+      });
+    });
+
+    describe('and initialValues are provided for the target segment', () => {
+      it('should apply initialValues for the target segment', () => {
+        const { getByTestId, getByRole } = render(getComponent({
+          contextInitialValues: {
+            [navigationSegments.browse]: {
+              dropdownValue: 'childrenSubjectHeading',
+              searchIndex: 'childrenSubjectHeading',
+              filters: { headingType: ['foo'] },
+            },
+          },
+        }));
+
+        fireEvent.click(getByRole('button', { name: 'Go to browse' }));
+
+        expect(getByTestId('navigationSegmentValue')).toHaveTextContent(navigationSegments.browse);
+        expect(getByTestId('searchDropdownValue')).toHaveTextContent('childrenSubjectHeading');
+        expect(getByTestId('searchIndex')).toHaveTextContent('childrenSubjectHeading');
+        expect(getByTestId('filters')).toHaveTextContent(JSON.stringify({ headingType: ['foo'] }));
+      });
+    });
+
+    describe('and switching back to a segment that has stored params', () => {
+      it('should restore the previously stored params', () => {
+        const { getByTestId, getByRole } = render(getComponent({
+          contextInitialValues: {
+            [navigationSegments.search]: {
+              dropdownValue: searchableIndexesValues.GENRE,
+              searchIndex: searchableIndexesValues.GENRE,
+              searchInputValue: 'search-query',
+              searchQuery: 'search-query',
+            },
+          },
+        }));
+
+        fireEvent.click(getByRole('button', { name: 'Go to browse' }));
+        fireEvent.click(getByRole('button', { name: 'Go to search' }));
+
+        expect(getByTestId('navigationSegmentValue')).toHaveTextContent(navigationSegments.search);
+        expect(getByTestId('searchQuery')).toHaveTextContent('search-query');
+        expect(getByTestId('searchIndex')).toHaveTextContent(searchableIndexesValues.GENRE);
+      });
+    });
+  });
+
+  describe('when resetAll is called', () => {
+    it('should reset search, filters, sort and mark going to base URL', () => {
+      const { getByTestId, getByRole } = render(getComponent({
+        contextInitialValues: {
+          [navigationSegments.search]: {
+            dropdownValue: searchableIndexesValues.GENRE,
+            searchIndex: searchableIndexesValues.GENRE,
+            searchInputValue: 'query',
+            searchQuery: 'query',
+          },
+        },
+      }));
+
+      fireEvent.click(getByRole('button', { name: 'Reset all' }));
+
+      expect(getByTestId('searchInputValue').textContent).toBe('');
+      expect(getByTestId('searchQuery').textContent).toBe('');
+      expect(getByTestId('searchDropdownValue')).toHaveTextContent(searchableIndexesValues.KEYWORD);
+      expect(getByTestId('searchIndex')).toHaveTextContent(searchableIndexesValues.KEYWORD);
+      expect(getByTestId('sortOrder')).toHaveTextContent(sortOrders.ASC);
+      expect(getByTestId('sortedColumn').textContent).toBe('');
+      expect(getByTestId('filters')).toHaveTextContent('{}');
+      expect(getByTestId('isGoingToBaseURL')).toHaveTextContent('true');
     });
   });
 });


### PR DESCRIPTION
## Description
When switching navigation segments, we need to call `setSearchIndex` with a previously saved searchIndex for the new navigation segment, as well as some other state variables. The issue is that calling `setFilters` also calls `setSearchIndex`, which overrides the initial call.
The solution is to call the internal `_setFilters` setter, which only updates the `filters` state, and doesn't touch any of the other variables.
Leaving the `setFilters` was an oversight in the previous PR that applied search parameters when applying filters - https://github.com/folio-org/stripes-authority-components/pull/227

## Issues
[UISAUTCOMP-177](https://folio-org.atlassian.net/browse/UISAUTCOMP-177)