### PR TITLE
UISAUTCOMP-178 Fix previous query is used instead of the current one after selecting "Authority source" option when searching MARC authority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - [UISAUTCOMP-176](https://folio-org.atlassian.net/browse/UISAUTCOMP-176) Apply search index and query when applying filters.
 - [UISAUTCOMP-150](https://folio-org.atlassian.net/browse/UISAUTCOMP-150) MARC authority | Hit "Enter" keyboard button must "click" on button elements.
+- [UISAUTCOMP-178](https://folio-org.atlassian.net/browse/UISAUTCOMP-178) Fix stale `setFilters` dep in `applyFilters` re-set query and index to old values when selecting a filter value.
 
 ## [7.0.1] (https://github.com/folio-org/stripes-authority-components/tree/v7.0.1) (2026-05-28)
 

--- a/lib/BrowseFilters/BrowseFilters.js
+++ b/lib/BrowseFilters/BrowseFilters.js
@@ -95,8 +95,7 @@ const BrowseFilters = ({
 
   const applyFilters = useCallback(({ name, values }) => {
     updateFilters({ name, values, setFilters });
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [setFilters]);
 
   const isVisible = filter => !excludedFilters.includes(filter);
 

--- a/lib/queries/useAuthoritiesBrowse/useAuthoritiesBrowse.js
+++ b/lib/queries/useAuthoritiesBrowse/useAuthoritiesBrowse.js
@@ -1,6 +1,5 @@
 import {
   useState,
-  useEffect,
   useMemo,
 } from 'react';
 import { useQuery } from 'react-query';
@@ -133,7 +132,6 @@ const useBrowserPaging = ({
     setBrowsePage(0);
     setBrowsePageQuery('');
     setPageQuery(buildPageQuery(_searchQuery, 0));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [_searchQuery, searchIndex, navigationSegmentValue]);
 
   return {
@@ -156,9 +154,6 @@ const useAuthoritiesBrowse = ({
   navigationSegmentValue,
   tenantId,
 }) => {
-  const [currentQuery, setCurrentQuery] = useState(searchQuery);
-  const [currentIndex, setCurrentIndex] = useState(searchIndex);
-
   const {
     pageQuery,
     setPageQuery,
@@ -173,12 +168,6 @@ const useAuthoritiesBrowse = ({
     setBrowsePage,
   });
 
-  useEffect(() => {
-    setCurrentQuery(searchQuery);
-    setCurrentIndex(searchIndex);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchQuery, searchIndex]);
-
   const {
     data,
     isFetched,
@@ -187,9 +176,9 @@ const useAuthoritiesBrowse = ({
     error,
   } = useBrowseRequest({
     filters,
-    searchQuery: currentQuery,
+    searchQuery,
     startingSearch: pageQuery,
-    searchIndex: currentIndex,
+    searchIndex,
     pageSize,
     precedingRecordsCount,
     tenantId,


### PR DESCRIPTION
## Description
Fix previous query is used instead of the current one after selecting "Authority source" option when searching MARC authority

Fix stale `setFilters` dep in `applyFilters` re-set query and index to old values when selecting a filter value.
Removed `currentQuery` and `currentIndex` states from `useAuthoritiesBrowse`, which are not necessary, and are just duplicates of the hook parameters

## Issues
[UISAUTCOMP-178](https://folio-org.atlassian.net/browse/UISAUTCOMP-178)